### PR TITLE
Repos, usage, s2i test

### DIFF
--- a/2.4/Dockerfile.rhel7
+++ b/2.4/Dockerfile.rhel7
@@ -15,9 +15,9 @@ LABEL io.k8s.description="Platform for running httpd or building httpd-based app
       io.openshift.expose-services="8443:https" \
       io.openshift.tags="builder,httpd,httpd24" \
       Component="httpd24-docker" \
-      Name="rhscl_beta/httpd-24-rhel7" \
+      Name="rhscl/httpd-24-rhel7" \
       Version="2.4" \
-      Release="28" \
+      Release="32" \
       BZComponent="httpd24-docker" \
       Architecture="x86_64"
 
@@ -38,7 +38,7 @@ COPY ./contrib/ /opt/app-root
 RUN yum install -y yum-utils gettext hostname && \
     yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
-    yum-config-manager --enable rhel-7-server-ose-3.0-rpms && \
+    yum-config-manager --enable rhel-7-server-ose-3.2-rpms && \
     INSTALL_PKGS="nss_wrapper bind-utils httpd24 httpd24-mod_ssl" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \

--- a/2.4/s2i/bin/usage
+++ b/2.4/s2i/bin/usage
@@ -1,6 +1,8 @@
 #!/bin/sh
 
 DISTRO=`cat /etc/*-release | grep ^ID= | grep -Po '".*?"' | tr -d '"'`
+NAMESPACE=centos
+[[ $DISTRO =~ rhel* ]] && NAMESPACE=rhscl
 
 cat <<EOF
 This is a S2I ${IMAGE_DESCRIPTION} ${DISTRO} base image:
@@ -8,8 +10,8 @@ To use it, install S2I: https://github.com/openshift/source-to-image
 
 Sample invocation:
 
-s2i build https://github.com/openshift/sti-perl.git --context-dir=5.16/test/sample-test-app/ openshift/perl-516-${DISTRO}7 perl-sample-app
+s2i build https://github.com/sclorg/httpd-container.git --context-dir=2.4/test/sample-test-app/ ${NAMESPACE}/httpd-24-${DISTRO}7 httpd-sample-app
 
 You can then run the resulting image via:
-docker run -p 8080:8080 perl-sample-app
+docker run -p 8080:8080 httpd-sample-app
 EOF

--- a/2.4/test/run
+++ b/2.4/test/run
@@ -4,12 +4,15 @@ IMAGE_NAME="${IMAGE_NAME:-rhscl/httpd-24-rhel7}"
 
 THISDIR=$(dirname ${BASH_SOURCE[0]})
 . ${THISDIR}/utils.sh
+test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
 
 function create_container() {
-    local name=$1 ; shift
+    local name="$1" ; shift
+    local image="${1-$IMAGE_NAME}" ; shift
     cidfile="$CIDFILE_DIR/$name"
     # create container with a cidfile in a directory for cleanup
-    docker run ${DOCKER_ARGS:-} --cidfile $cidfile -d $IMAGE_NAME || return 1
+    docker run ${DOCKER_ARGS:-} --cidfile $cidfile -d $image || return 1
+    echo docker run ${DOCKER_ARGS:-} --cidfile $cidfile -d $image
     echo "Created container $(cat $cidfile)"
 }
 
@@ -93,6 +96,22 @@ sleep 2
 run "curl localhost > output"
 run "grep -e '^hello$' output"
 rm_container test_doc_root
+
+# Test s2i use case
+# Since we built the candidate image locally, we don't want S2I attempt to pull
+# it from Docker hub
+s2i_args="--force-pull=false"
+run "s2i usage ${s2i_args} ${IMAGE_NAME}" 0 "Testing 's2i usage'"
+run "s2i build ${s2i_args} file://${test_dir}/sample-test-app ${IMAGE_NAME} ${IMAGE_NAME}-testapp" 0 "Testing 's2i build'"
+DOCKER_ARGS='-p 8080:8080 -u 1000'
+create_container testing-app-s2i ${IMAGE_NAME}-testapp
+DOCKER_ARGS=
+sleep 5
+run "curl localhost:8080 > output_s2i"
+run "fgrep -e 'This is a sample s2i application with static content.' output_s2i"
+# 0 "Checking page served by s2i feature"
+sleep 2
+rm_container "testing-app-s2i"
 
 popd > /dev/null
 rm -Rf "$tmpdir"

--- a/2.4/test/sample-test-app/index.html
+++ b/2.4/test/sample-test-app/index.html
@@ -1,0 +1,1 @@
+This is a sample s2i application with static content.


### PR DESCRIPTION
Use OSE 3.2 repo for nss_wrapper
Do not use beta repo for RHSCL
Fix usage message and links there
Add test for s2i usage