### PR TITLE
Fix copying of custom conf files

### DIFF
--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -38,7 +38,7 @@ RUN yum install -y yum-utils gettext hostname && \
 
 ENV HTTPD_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/httpd/ \
     HTTPD_APP_ROOT=/opt/app-root \
-    HTTPD_CONFIGURATION_PATH=${HTTPD_APP_ROOT}/etc/httpd.d \
+    HTTPD_CONFIGURATION_PATH=/opt/app-root/etc/httpd.d \
     HTTPD_MAIN_CONF_PATH=/etc/httpd/conf \
     HTTPD_MAIN_CONF_D_PATH=/etc/httpd/conf.d \
     HTTPD_VAR_RUN=/var/run/httpd \

--- a/2.4/Dockerfile.fedora
+++ b/2.4/Dockerfile.fedora
@@ -48,7 +48,7 @@ RUN dnf install -y yum-utils gettext hostname && \
 
 ENV HTTPD_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/httpd/ \
     HTTPD_APP_ROOT=/opt/app-root \
-    HTTPD_CONFIGURATION_PATH=${HTTPD_APP_ROOT}/etc/httpd.d \
+    HTTPD_CONFIGURATION_PATH=/opt/app-root/etc/httpd.d \
     HTTPD_MAIN_CONF_PATH=/etc/httpd/conf \
     HTTPD_MAIN_CONF_D_PATH=/etc/httpd/conf.d \
     HTTPD_VAR_RUN=/var/run/httpd \

--- a/2.4/Dockerfile.rhel7
+++ b/2.4/Dockerfile.rhel7
@@ -46,7 +46,7 @@ RUN yum install -y yum-utils gettext hostname && \
 
 ENV HTTPD_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/httpd/ \
     HTTPD_APP_ROOT=/opt/app-root \
-    HTTPD_CONFIGURATION_PATH=${HTTPD_APP_ROOT}/etc/httpd.d \
+    HTTPD_CONFIGURATION_PATH=/opt/app-root/etc/httpd.d \
     HTTPD_MAIN_CONF_PATH=/etc/httpd/conf \
     HTTPD_MAIN_CONF_D_PATH=/etc/httpd/conf.d \
     HTTPD_VAR_RUN=/var/run/httpd \


### PR DESCRIPTION
Definition of environment variable in dockerfile `ENV` instruction can't use value of variable defined in same dockerfile instruction.

Resolves: #14

@hhorak @pkubatrh  Please take a look and merge.