### PR TITLE
Dockerfiles update

### DIFF
--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -22,7 +22,11 @@ LABEL summary="$SUMMARY" \
       io.k8s.description="$SUMMARY" \
       io.k8s.display-name="Apache httpd $HTTPD_VERSION" \
       io.openshift.expose-services="8080:http,8443:https" \
-      io.openshift.tags="builder,httpd,httpd24"
+      io.openshift.tags="builder,httpd,httpd24" \
+      name="centos/httpd-24-centos7" \
+      version="$HTTPD_VERSION" \
+      release="1" \
+      com.redhat.component="httpd24-docker"
 
 EXPOSE 80
 EXPOSE 443

--- a/2.4/Dockerfile.fedora
+++ b/2.4/Dockerfile.fedora
@@ -8,7 +8,11 @@ FROM 25/s2i-base
 # Environment:
 #  * $HTTPD_LOG_TO_VOLUME (optional) - When set, httpd will log into /var/log/httpd
 
-ENV HTTPD_VERSION=2.4
+ENV HTTPD_VERSION=2.4 \
+    NAME=httpd \
+    VERSION=$HTTPD_VERSION \
+    RELEASE=1 \
+    ARCH=x86_64
 
 ENV SUMMARY="Platform for running Apache httpd $HTTPD_VERSION or building httpd-based application" \
     DESCRIPTION="Apache httpd $HTTPD_VERSION available as docker container, is a powerful, efficient, \
@@ -22,14 +26,8 @@ LABEL summary="$SUMMARY" \
       io.k8s.description="$SUMMARY" \
       io.k8s.display-name="Apache httpd $HTTPD_VERSION" \
       io.openshift.expose-services="8080:http,8443:https" \
-      io.openshift.tags="builder,httpd,httpd24"
-
-ENV NAME=httpd \
-    VERSION=$HTTPD_VERSION \
-    RELEASE=1 \
-    ARCH=x86_64
-
-LABEL com.redhat.component="$NAME" \
+      io.openshift.tags="builder,httpd,httpd24" \
+      com.redhat.component="$NAME" \
       name="$FGC/$NAME" \
       version="$VERSION" \
       release="$RELEASE.$DISTTAG" \

--- a/2.4/Dockerfile.rhel7
+++ b/2.4/Dockerfile.rhel7
@@ -22,13 +22,11 @@ LABEL summary="$SUMMARY" \
       io.k8s.description="$SUMMARY" \
       io.k8s.display-name="Apache httpd $HTTPD_VERSION" \
       io.openshift.expose-services="8080:http,8443:https" \
-      io.openshift.tags="builder,httpd,httpd24"
-
-LABEL name="rhscl/httpd-24-rhel7" \
+      io.openshift.tags="builder,httpd,httpd24" \
+      name="rhscl/httpd-24-rhel7" \
       version="$HTTPD_VERSION" \
       release="32" \
-      com.redhat.component="httpd24-docker" \
-      architecture="x86_64"
+      com.redhat.component="httpd24-docker"
 
 EXPOSE 80
 EXPOSE 443


### PR DESCRIPTION
Provide same labels for all base image variants (CentOS, RHEL, Fedora)
- add name and version labels
- remove architecture label for RHEL based images (this label is set in RHEL image - no need to define it again)
    
    (don't use separate instruction for each label)

@hhorak @praiskup @pkubatrh Please take a look and merge.