### PR TITLE
removed privileged ports definitions

### DIFF
--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -28,8 +28,8 @@ LABEL summary="$SUMMARY" \
       release="1" \
       com.redhat.component="httpd24-docker"
 
-EXPOSE 80
-EXPOSE 443
+# EXPOSE 80
+# EXPOSE 443
 EXPOSE 8080
 EXPOSE 8443
 

--- a/2.4/Dockerfile.fedora
+++ b/2.4/Dockerfile.fedora
@@ -33,8 +33,8 @@ LABEL summary="$SUMMARY" \
       release="$RELEASE.$DISTTAG" \
       architecture="$ARCH"
 
-EXPOSE 80
-EXPOSE 443
+# EXPOSE 80
+# EXPOSE 443
 EXPOSE 8080
 EXPOSE 8443
 

--- a/2.4/Dockerfile.rhel7
+++ b/2.4/Dockerfile.rhel7
@@ -28,8 +28,8 @@ LABEL summary="$SUMMARY" \
       release="32" \
       com.redhat.component="httpd24-docker"
 
-EXPOSE 80
-EXPOSE 443
+# EXPOSE 80
+# EXPOSE 443
 EXPOSE 8080
 EXPOSE 8443
 


### PR DESCRIPTION
While running the containers under Kubernetes or other orchestration, it is preferable to avoid using privileged ports for unnecessary privileges. The orchestration systems will route traffic appropriately.