### PR TITLE
Do not expose ports that are not used by default

### DIFF
--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -28,8 +28,6 @@ LABEL summary="$SUMMARY" \
       release="1" \
       com.redhat.component="httpd24-docker"
 
-EXPOSE 80
-EXPOSE 443
 EXPOSE 8080
 EXPOSE 8443
 

--- a/2.4/Dockerfile.fedora
+++ b/2.4/Dockerfile.fedora
@@ -33,8 +33,6 @@ LABEL summary="$SUMMARY" \
       release="$RELEASE.$DISTTAG" \
       architecture="$ARCH"
 
-EXPOSE 80
-EXPOSE 443
 EXPOSE 8080
 EXPOSE 8443
 

--- a/2.4/Dockerfile.rhel7
+++ b/2.4/Dockerfile.rhel7
@@ -28,8 +28,6 @@ LABEL summary="$SUMMARY" \
       release="32" \
       com.redhat.component="httpd24-docker"
 
-EXPOSE 80
-EXPOSE 443
 EXPOSE 8080
 EXPOSE 8443
 


### PR DESCRIPTION
Historically the image ran as root by default, so it could use root-only ports 80 and 443, but since the image runs as non-root by default now, we cannot run it easily on those ports, so they should not be exposed. Exposing ports that are not used can trick services that depend on them, like OpenShift, that uses the export ports to automatic route creation.