### PR TITLE
Add pre-init scripts functionality

### DIFF
--- a/2.4/root/usr/bin/run-httpd
+++ b/2.4/root/usr/bin/run-httpd
@@ -13,4 +13,6 @@ else
   generate_container_user
 fi
 
+process_extending_files ${HTTPD_APP_ROOT}/src/httpd-pre-init/ ${HTTPD_CONTAINER_SCRIPTS_PATH}/pre-init/
+
 exec httpd -D FOREGROUND $@

--- a/2.4/root/usr/libexec/httpd-prepare
+++ b/2.4/root/usr/libexec/httpd-prepare
@@ -32,5 +32,7 @@ chown -R 1001:0 ${HTTPD_APP_ROOT}
 chown -R 1001:0 ${HTTPD_DATA_PATH}
 chown -R 1001:0 ${HTTPD_LOG_PATH}
 
+mkdir -p ${HTTPD_CONTAINER_SCRIPTS_PATH}/pre-init
+
 config_general
 

--- a/2.4/root/usr/share/container-scripts/httpd/README.md
+++ b/2.4/root/usr/share/container-scripts/httpd/README.md
@@ -57,6 +57,13 @@ To run such a new image, execute the following command:
 $ docker run -d --name httpd -p 8080:8080 httpd-app
 ```
 
+The structure of httpd-app can look like this:
+
+| Folder name       | Description                |
+|-------------------|----------------------------|
+| `./httpd-cfg`     | Can contain additional Apache configuration files (`*.cfg`)|
+| `./httpd-pre-init`| Can contain shell scripts (`*.sh`) that are sourced before `httpd` is started|
+| `./`              | Application source code |
 
 Environment variables and volumes
 ---------------------------------

--- a/2.4/root/usr/share/container-scripts/httpd/common.sh
+++ b/2.4/root/usr/share/container-scripts/httpd/common.sh
@@ -49,6 +49,34 @@ config_non_privileged() {
   fi
 }
 
+# get_matched_files finds file for image extending
+function get_matched_files() {
+  local custom_dir default_dir
+  custom_dir="$1"
+  default_dir="$2"
+  files_matched="$3"
+  find "$default_dir" -maxdepth 1 -type f -name "$files_matched" -printf "%f\n"
+  [ -d "$custom_dir" ] && find "$custom_dir" -maxdepth 1 -type f -name "$files_matched" -printf "%f\n"
+}
+
+# process_extending_files process extending files in $1 and $2 directories
+# - source all *.sh files
+#   (if there are files with same name source only file from $1)
+function process_extending_files() {
+  local custom_dir default_dir
+  custom_dir=$1
+  default_dir=$2
+  while read filename ; do
+    echo "=> sourcing $filename ..."
+    # Custom file is prefered
+    if [ -f $custom_dir/$filename ]; then
+      source $custom_dir/$filename
+    elif [ -f $default_dir/$filename ]; then 
+      source $default_dir/$filename
+    fi
+  done <<<"$(get_matched_files "$custom_dir" "$default_dir" '*.sh' | sort -u)"
+}
+
 # Set current user in nss_wrapper
 generate_container_user() {
   local passwd_output_dir="${HTTPD_APP_ROOT}/etc"

--- a/2.4/test/pre-init-test-app/httpd-pre-init/modify_index.sh
+++ b/2.4/test/pre-init-test-app/httpd-pre-init/modify_index.sh
@@ -1,0 +1,1 @@
+echo 'This content was replaced by pre-init script.' > ${HTTPD_APP_ROOT}/src/index.html

--- a/2.4/test/pre-init-test-app/index.html
+++ b/2.4/test/pre-init-test-app/index.html
@@ -1,0 +1,1 @@
+This is a sample s2i application with static content.

--- a/2.4/test/run
+++ b/2.4/test/run
@@ -176,6 +176,22 @@ function run_s2i_test() {
   sleep 2
 }
 
+function run_pre_init_test() {
+  # Test s2i use case #2 - testing pre-init script
+  # Since we built the candidate image locally, we don't want S2I attempt to pull
+  # it from Docker hub
+  s2i_args="--force-pull=false"
+  run "s2i build ${s2i_args} file://${test_dir}/pre-init-test-app ${IMAGE_NAME} ${IMAGE_NAME}-testapp2" 0 "Testing 's2i build' with pre-init script"
+  DOCKER_ARGS='-u 1000'
+  create_container testing-app-pre-init ${IMAGE_NAME}-testapp2
+  DOCKER_ARGS=
+  sleep 5
+  cip=$(get_container_ip 'testing-app-pre-init')
+  run "curl ${cip}:8080 > output_pre_init"
+  run "fgrep -e 'This content was replaced by pre-init script.' output_pre_init"
+  # 0 "Checking page served by s2i feature and edited by pre-init script"
+  sleep 2
+}
 
 function run_all_tests() {
   for test_case in $TEST_LIST; do
@@ -228,7 +244,8 @@ run_default_page_test
 run_as_root_test
 run_log_to_volume_test
 run_data_volume_test
-run_s2i_test"
+run_s2i_test
+run_pre_init_test"
 
 test $# -eq 1 -a "${1-}" == --list && echo "$TEST_LIST" && exit 0
 


### PR DESCRIPTION
This PR adds ability to have pre-init scripts in the httpd s2i image, in the same way as in [sclorg/mongodb-container](https://github.com/sclorg/mongodb-container). It also comes with a test that validates this functionality. 