### PR TITLE
Do not use VOLUMES because it fails in OpenShift Online

### DIFF
--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -64,7 +64,9 @@ RUN /usr/libexec/httpd-prepare && rpm-file-permissions
 
 USER 1001
 
-VOLUME ["${HTTPD_DATA_PATH}"]
-VOLUME ["${HTTPD_LOG_PATH}"]
+# Not using VOLUME statement since it's not working in OpenShift Online:
+# https://github.com/sclorg/httpd-container/issues/30
+# VOLUME ["${HTTPD_DATA_PATH}"]
+# VOLUME ["${HTTPD_LOG_PATH}"]
 
 CMD ["/usr/bin/run-httpd"]

--- a/2.4/Dockerfile.fedora
+++ b/2.4/Dockerfile.fedora
@@ -61,7 +61,9 @@ RUN /usr/libexec/httpd-prepare
 
 USER 1001
 
-VOLUME ["${HTTPD_DATA_PATH}"]
-VOLUME ["${HTTPD_LOG_PATH}"]
+# Not using VOLUME statement since it's not working in OpenShift Online:
+# https://github.com/sclorg/httpd-container/issues/30
+# VOLUME ["${HTTPD_DATA_PATH}"]
+# VOLUME ["${HTTPD_LOG_PATH}"]
 
 CMD ["/usr/bin/run-httpd"]

--- a/2.4/Dockerfile.rhel7
+++ b/2.4/Dockerfile.rhel7
@@ -66,7 +66,9 @@ RUN /usr/libexec/httpd-prepare && rpm-file-permissions
 
 USER 1001
 
-VOLUME ["${HTTPD_DATA_PATH}"]
-VOLUME ["${HTTPD_LOG_PATH}"]
+# Not using VOLUME statement since it's not working in OpenShift Online:
+# https://github.com/sclorg/httpd-container/issues/30
+# VOLUME ["${HTTPD_DATA_PATH}"]
+# VOLUME ["${HTTPD_LOG_PATH}"]
 
 CMD ["/usr/bin/run-httpd"]


### PR DESCRIPTION
It's rationalized in #30.

Ideally this should be reverted once OpenShift Online is fixed.