### PR TITLE
Various small documentation related changes

### DIFF
--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -40,8 +40,8 @@ RUN yum install -y yum-utils && \
     yum clean all
 
 ENV HTTPD_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/httpd/ \
-    HTTPD_APP_ROOT=/opt/app-root \
-    HTTPD_CONFIGURATION_PATH=/opt/app-root/etc/httpd.d \
+    HTTPD_APP_ROOT=${APP_ROOT} \
+    HTTPD_CONFIGURATION_PATH=${APP_ROOT}/etc/httpd.d \
     HTTPD_MAIN_CONF_PATH=/etc/httpd/conf \
     HTTPD_MAIN_CONF_D_PATH=/etc/httpd/conf.d \
     HTTPD_VAR_RUN=/var/run/httpd \

--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -26,6 +26,7 @@ LABEL summary="$SUMMARY" \
       name="centos/httpd-24-centos7" \
       version="$HTTPD_VERSION" \
       com.redhat.component="httpd24-docker" \
+      usage="s2i build https://github.com/sclorg/httpd-container.git --context-dir=examples/sample-test-app/ centos/httpd-24-centos7 sample-server" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 EXPOSE 8080

--- a/2.4/Dockerfile.fedora
+++ b/2.4/Dockerfile.fedora
@@ -45,8 +45,8 @@ RUN dnf install -y yum-utils gettext hostname && \
     dnf clean all
 
 ENV HTTPD_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/httpd/ \
-    HTTPD_APP_ROOT=/opt/app-root \
-    HTTPD_CONFIGURATION_PATH=/opt/app-root/etc/httpd.d \
+    HTTPD_APP_ROOT=${APP_ROOT} \
+    HTTPD_CONFIGURATION_PATH=${APP_ROOT}/etc/httpd.d \
     HTTPD_MAIN_CONF_PATH=/etc/httpd/conf \
     HTTPD_MAIN_CONF_D_PATH=/etc/httpd/conf.d \
     HTTPD_VAR_RUN=/var/run/httpd \

--- a/2.4/Dockerfile.fedora
+++ b/2.4/Dockerfile.fedora
@@ -32,7 +32,7 @@ LABEL summary="$SUMMARY" \
       version="$VERSION" \
       release="$RELEASE.$DISTTAG" \
       architecture="$ARCH" \
-      run="docker run -d --name httpd -p 8080:8080 -v /wwwdata:/var/www:Z $FGC/$NAME:latest" \
+      usage="s2i build https://github.com/sclorg/httpd-container.git --context-dir=examples/sample-test-app/ $FGC/$NAME sample-server" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 EXPOSE 8080

--- a/2.4/Dockerfile.rhel7
+++ b/2.4/Dockerfile.rhel7
@@ -43,8 +43,8 @@ RUN yum install -y yum-utils && \
     yum clean all
 
 ENV HTTPD_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/httpd/ \
-    HTTPD_APP_ROOT=/opt/app-root \
-    HTTPD_CONFIGURATION_PATH=/opt/app-root/etc/httpd.d \
+    HTTPD_APP_ROOT=${APP_ROOT} \
+    HTTPD_CONFIGURATION_PATH=${APP_ROOT}/etc/httpd.d \
     HTTPD_MAIN_CONF_PATH=/etc/httpd/conf \
     HTTPD_MAIN_CONF_D_PATH=/etc/httpd/conf.d \
     HTTPD_VAR_RUN=/var/run/httpd \

--- a/2.4/Dockerfile.rhel7
+++ b/2.4/Dockerfile.rhel7
@@ -25,7 +25,9 @@ LABEL summary="$SUMMARY" \
       io.openshift.tags="builder,httpd,httpd24" \
       name="rhscl/httpd-24-rhel7" \
       version="$HTTPD_VERSION" \
-      com.redhat.component="httpd24-docker"
+      com.redhat.component="httpd24-docker" \
+      usage="s2i build https://github.com/sclorg/httpd-container.git --context-dir=examples/sample-test-app/ rhscl/httpd-24-rhel7 sample-server" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 EXPOSE 8080
 EXPOSE 8443

--- a/2.4/root/usr/share/container-scripts/httpd/README.md
+++ b/2.4/root/usr/share/container-scripts/httpd/README.md
@@ -59,21 +59,30 @@ $ docker run -d --name httpd -p 8080:8080 httpd-app
 
 The structure of httpd-app can look like this:
 
-| Folder name       | Description                |
-|-------------------|----------------------------|
-| `./httpd-cfg`     | Can contain additional Apache configuration files (`*.conf`)|
-| `./httpd-pre-init`| Can contain shell scripts (`*.sh`) that are sourced before `httpd` is started|
-| `./httpd-ssl`     | Can contain own SSL certificate (in `certs/` subdirectory) and key (in `private/` subdirectory)|
-| `./`              | Application source code |
+**`Folder name`**  
+       Description
+
+**`./httpd-cfg`**  
+       Can contain additional Apache configuration files (`*.conf`)
+
+**`./httpd-pre-init`**  
+       Can contain shell scripts (`*.sh`) that are sourced before `httpd` is started
+
+**`./httpd-ssl`**  
+       Can contain own SSL certificate (in `certs/` subdirectory) and key (in `private/` subdirectory)
+
+**`./`**  
+       Application source code
+
 
 Environment variables and volumes
 ---------------------------------
 
 The Apache HTTP Server container image supports the following configuration variable, which can be set by using the `-e` option with the docker run command:
 
-|    Variable name        |    Description                            |
-| :---------------------- | ----------------------------------------- |
-|  `HTTPD_LOG_TO_VOLUME` | By default, httpd logs into standard output, so the logs are accessible by using the docker logs command. When `HTTPD_LOG_TO_VOLUME` is set, httpd logs into `/var/log/httpd24`, which can be mounted to host system using the Docker volumes. This option is only allowed when container is run as UID 0. |
+**`HTTPD_LOG_TO_VOLUME`**  
+       By default, httpd logs into standard output, so the logs are accessible by using the docker logs command. When `HTTPD_LOG_TO_VOLUME` is set, httpd logs into `/var/log/httpd24`, which can be mounted to host system using the Docker volumes. This option is only allowed when container is run as UID 0.
+
 
 
 If you want to run the image and mount the log files into `/wwwlogs` on the host
@@ -85,10 +94,12 @@ $ docker run -d -u 0 -e HTTPD_LOG_TO_VOLUME=1 --name httpd -v /wwwlogs:/var/log/
 
 You can also set the following mount points by passing the `-v /host:/container` flag to Docker.
 
-|  Volume mount point      | Description                                                            |
-| :----------------------- | ---------------------------------------------------------------------- |
-|  `/var/www`              | Apache HTTP Server data directory                                      |
-|  `/var/log/httpd24`      | Apache HTTP Server log directory (available only when running as root, path `/var/log/httpd` is used in case of Fedora based image) |
+**`/var/www`**  
+       Apache HTTP Server data directory
+
+**`/var/log/httpd24`**  
+       Apache HTTP Server log directory (available only when running as root, path `/var/log/httpd` is used in case of Fedora based image)
+
 
 **Notice: When mouting a directory from the host into the container, ensure that the mounted
 directory has the appropriate permissions and that the owner and group of the directory

--- a/2.4/root/usr/share/container-scripts/httpd/README.md
+++ b/2.4/root/usr/share/container-scripts/httpd/README.md
@@ -59,9 +59,6 @@ $ docker run -d --name httpd -p 8080:8080 httpd-app
 
 The structure of httpd-app can look like this:
 
-**`Folder name`**  
-       Description
-
 **`./httpd-cfg`**  
        Can contain additional Apache configuration files (`*.conf`)
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Choose either the CentOS7 or RHEL7 based image:
 
 *  **RHEL7 based image**
 
-    This image is available in Red Hat Container Registry. To download it run:
+    These images are available in the [Red Hat Container Catalog](https://access.redhat.com/containers/#/registry.access.redhat.com/rhscl/httpd-24-rhel7).
+    To download it run:
 
     ```
     $ docker pull registry.access.redhat.com/rhscl/httpd-24-rhel7


### PR DESCRIPTION
Use maintainer label consistently
Few edits in top-level README
Remove tables in README, because go-md2man cannot convert them properly
Remove hard-coded /opt/app-root in Dockerfile