### PR TITLE
[DO NOT MERGE] Generate certificats that are no longer in rpm

### DIFF
--- a/2.4/Dockerfile.fedora
+++ b/2.4/Dockerfile.fedora
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/f29/s2i-core:latest
+FROM registry.fedoraproject.org/f33/s2i-core:latest
 
 # Apache HTTP Server image.
 #
@@ -57,7 +57,8 @@ COPY ./root /
 
 # Generate SSL certs and reset permissions of filesystem to default values
 # Reset permissions of filesystem to default values
-RUN /usr/libexec/httpd-prepare && rpm-file-permissions
+RUN /usr/libexec/httpd-ssl-gencerts && \
+    /usr/libexec/httpd-prepare && rpm-file-permissions
 
 USER 1001
 

--- a/2.4/root/usr/share/container-scripts/httpd/common.sh
+++ b/2.4/root/usr/share/container-scripts/httpd/common.sh
@@ -2,6 +2,8 @@
 
 if head "/etc/redhat-release" | grep -q "^Red Hat Enterprise Linux release 8"; then
   HTTPCONF_LINENO=154
+elif head "/etc/redhat-release" | grep -q "^Fedora"; then
+  HTTPCONF_LINENO=154
 else
   HTTPCONF_LINENO=151
 fi


### PR DESCRIPTION
This also fixes the BZ for this issue:
https://bugzilla.redhat.com/show_bug.cgi?id=1585533