### PR TITLE
Allow mounting SSL certificates directly to ${HTTPD_APP_ROOT}/httpd-ssl

### DIFF
--- a/2.4/root/usr/share/container-scripts/httpd/common.sh
+++ b/2.4/root/usr/share/container-scripts/httpd/common.sh
@@ -114,8 +114,11 @@ process_config_files() {
 process_ssl_certs() {
   local dir=${1:-.}
   if [ -d ${dir}/httpd-ssl/private ] && [ -d ${dir}/httpd-ssl/certs ]; then
+    echo "---> Moving the httpd-ssl directory included in the source to a directory that isn't exposed by httpd..."
+    mv ${dir}/httpd-ssl ${HTTPD_APP_ROOT}
+  fi
+  if [ -d ${HTTPD_APP_ROOT}/httpd-ssl/private ] && [ -d ${HTTPD_APP_ROOT}/httpd-ssl/certs ]; then
     echo "---> Looking for SSL certs for httpd..."
-    cp -r ${dir}/httpd-ssl ${HTTPD_APP_ROOT}
     local ssl_cert="$(ls -A ${HTTPD_APP_ROOT}/httpd-ssl/certs/*.pem | head -n 1)"
     local ssl_private="$(ls -A ${HTTPD_APP_ROOT}/httpd-ssl/private/*.pem | head -n 1)"
     if [ -f "${ssl_cert}" ] ; then
@@ -130,7 +133,6 @@ process_ssl_certs() {
         sed -i '/^SSLCertificateKeyFile .*/d'  ${HTTPD_MAIN_CONF_D_PATH}/ssl.conf
       fi
     fi
-    rm -rf ${dir}/httpd-ssl
   fi
 }
 


### PR DESCRIPTION
I'm trying to configure HTTPS in OpenShift using passthrough TLS on an image built with this S2I image. I want to do this by mounting my certs in the pod at `${HTTPD_APP_ROOT}/httpd-ssl`. The issue is that the image expects the certs to first be included in the source and then be copied over to `${HTTPD_APP_ROOT}/httpd-ssl`. Once they are copied over, the certs included in the source are removed. If I mount the certs in the source like the image expects, it ends up trying to delete the mounted volume which fails and causes the pod to crash.

Based on feedback from @omron93 in this PR, I modified the script to move the SSL certs from the source if they exist, but also check if they are present in a separate if condition.