### PR TITLE
Move fedora specific code into fedora Dockerfile

### DIFF
--- a/2.4/Dockerfile.fedora
+++ b/2.4/Dockerfile.fedora
@@ -57,7 +57,9 @@ ENV HTTPD_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/httpd/ \
 COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 COPY ./root /
 
-RUN /usr/libexec/httpd-prepare
+# Generate SSL certs and reset permissions of filesystem to default values
+RUN /usr/libexec/httpd-ssl-gencerts && \
+    /usr/libexec/httpd-prepare && rpm-file-permissions
 
 USER 1001
 

--- a/2.4/root/usr/libexec/httpd-prepare
+++ b/2.4/root/usr/libexec/httpd-prepare
@@ -4,10 +4,6 @@ set -e
 
 source ${HTTPD_CONTAINER_SCRIPTS_PATH}/common.sh
 
-# Fedora httpd-mod_ssl package generates certificates on service start,
-# so they need to be generated manually
-test -f /etc/pki/tls/certs/localhost.crt || /usr/libexec/httpd-ssl-gencerts
-
 # compatibility symlinks so we hide SCL paths
 if [ -v HTTPD_SCL ] ; then
   # /opt/rh/httpd24/root/etc/httpd will be symlink to /etc/httpd


### PR DESCRIPTION
In SCL based images, there is no `/usr/libexec/httpd-prepare`. So it makes more sense to move the code into fedora Dockerfile.

Such fix was already implemented downstream in Fedora registry. So using same logic in our repo.