### PR TITLE
Removing Version Typo from Image Stream Descriptions

### DIFF
--- a/imagestreams/httpd-centos7.json
+++ b/imagestreams/httpd-centos7.json
@@ -11,7 +11,7 @@
     "tags": [
       {
         "annotations": {
-          "description": "Build and serve static content via Apache HTTP Server (httpd) on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/httpd-container/blob/master/2.4/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Httpd available on OpenShift, including major versions updates.",
+          "description": "Build and serve static content via Apache HTTP Server (httpd) on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/httpd-container/blob/master/2.4/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Httpd available on OpenShift, including major version updates.",
           "iconClass": "icon-apache",
           "openshift.io/display-name": "Apache HTTP Server (Latest)",
           "openshift.io/provider-display-name": "Red Hat, Inc.",

--- a/imagestreams/httpd-rhel7-ppc64le.json
+++ b/imagestreams/httpd-rhel7-ppc64le.json
@@ -11,7 +11,7 @@
     "tags": [
       {
         "annotations": {
-          "description": "Build and serve static content via Apache HTTP Server (httpd) on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/httpd-container/blob/master/2.4/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Httpd available on OpenShift, including major versions updates.",
+          "description": "Build and serve static content via Apache HTTP Server (httpd) on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/httpd-container/blob/master/2.4/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Httpd available on OpenShift, including major version updates.",
           "iconClass": "icon-apache",
           "openshift.io/display-name": "Apache HTTP Server (Latest)",
           "openshift.io/provider-display-name": "Red Hat, Inc.",

--- a/imagestreams/httpd-rhel7.json
+++ b/imagestreams/httpd-rhel7.json
@@ -11,7 +11,7 @@
     "tags": [
       {
         "annotations": {
-          "description": "Build and serve static content via Apache HTTP Server (httpd) on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/httpd-container/blob/master/2.4/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Httpd available on OpenShift, including major versions updates.",
+          "description": "Build and serve static content via Apache HTTP Server (httpd) on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/httpd-container/blob/master/2.4/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Httpd available on OpenShift, including major version updates.",
           "iconClass": "icon-apache",
           "openshift.io/display-name": "Apache HTTP Server (Latest)",
           "openshift.io/provider-display-name": "Red Hat, Inc.",


### PR DESCRIPTION
This pull request removes a minor typo for all the image stream descriptions.