### PR TITLE
Add modifications from rhscl 3.3

### DIFF
--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -34,7 +34,7 @@ EXPOSE 8443
 
 RUN yum install -y yum-utils && \
     yum install -y centos-release-scl epel-release && \
-    INSTALL_PKGS="gettext hostname nss_wrapper bind-utils httpd24 httpd24-mod_ssl httpd24-mod_auth_mellon" && \
+    INSTALL_PKGS="gettext hostname nss_wrapper bind-utils httpd24 httpd24-mod_ssl httpd24-mod_auth_mellon httpd24-mod_security" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum -y clean all --enablerepo='*'

--- a/2.4/root/usr/libexec/httpd-prepare
+++ b/2.4/root/usr/libexec/httpd-prepare
@@ -35,6 +35,7 @@ chmod -R a+rwx ${HTTPD_APP_ROOT}/etc
 chmod -R a+rwx ${HTTPD_VAR_RUN}
 chown -R 1001:0 ${HTTPD_APP_ROOT}
 chown -R 1001:0 ${HTTPD_DATA_PATH}
+chmod -R g+rwx ${HTTPD_LOG_PATH}
 chown -R 1001:0 ${HTTPD_LOG_PATH}
 
 mkdir -p ${HTTPD_CONTAINER_SCRIPTS_PATH}/pre-init


### PR DESCRIPTION
add mod_security

Allow writing the group to /var/log/httpd24
Otherwise mod_security was not able to write a log to this directory when the container was run under UID 1000, we saw this error:
ModSecurity: Failed to open debug log file: /var/log/httpd24/modsec_debug.log