### PR TITLE
Fix permissions for all files given in s2i

### DIFF
--- a/2.4/s2i/bin/assemble
+++ b/2.4/s2i/bin/assemble
@@ -9,7 +9,10 @@ echo "---> Enabling s2i support in httpd24 image"
 config_s2i
 
 echo "---> Installing application source"
-cp -Rf /tmp/src/. ./
+cp -af /tmp/src/. ./
+
+# Fix source directory permissions
+fix-permissions ./
 
 process_extending_files ${HTTPD_APP_ROOT}/src/httpd-post-assemble/ ${HTTPD_CONTAINER_SCRIPTS_PATH}/post-assemble/
 


### PR DESCRIPTION
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>

Adds fix-permissions right after `cp` and add `-a` to `cp`

Reference issue:
https://github.com/sclorg/container-common-scripts/issues/119
