### PR TITLE
[fedora] Don't install yum-utils and update to F34

### DIFF
--- a/2.4/Dockerfile.fedora
+++ b/2.4/Dockerfile.fedora
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/f29/s2i-core:latest
+FROM registry.fedoraproject.org/f34/s2i-core:latest
 
 # Apache HTTP Server image.
 #

--- a/2.4/Dockerfile.fedora
+++ b/2.4/Dockerfile.fedora
@@ -34,7 +34,7 @@ LABEL summary="$SUMMARY" \
 EXPOSE 8080
 EXPOSE 8443
 
-RUN dnf install -y yum-utils gettext hostname && \
+RUN dnf install -y gettext hostname && \
     INSTALL_PKGS="nss_wrapper bind-utils httpd mod_ssl mod_ldap mod_session mod_security sscg" && \
     dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \


### PR DESCRIPTION
Hi,

I needed an F30 based httpd image and since there's no such in registry.fedoraproject.org I had to [build it](https://cloud.docker.com/u/usercont/repository/docker/usercont/httpd).
While doing that I realized there are lots of python 2 dependencies installed and the cause turned out to be `yum-utils`. It's not used during the build process, so I guess it's been there from some historical reasons and it's not needed anymore?