### PR TITLE
The private key and cert should not be stored in the base image. Gene…

### DIFF
--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -34,7 +34,7 @@ EXPOSE 8443
 
 RUN yum install -y yum-utils && \
     yum install -y centos-release-scl epel-release && \
-    INSTALL_PKGS="gettext hostname nss_wrapper bind-utils httpd24 httpd24-mod_ssl httpd24-mod_auth_mellon httpd24-mod_security" && \
+    INSTALL_PKGS="gettext hostname nss_wrapper bind-utils httpd24 httpd24-mod_ssl httpd24-mod_auth_mellon httpd24-mod_security openssl" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum -y clean all --enablerepo='*'
@@ -45,6 +45,7 @@ ENV HTTPD_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/httpd/ \
     HTTPD_MAIN_CONF_PATH=/etc/httpd/conf \
     HTTPD_MAIN_CONF_MODULES_D_PATH=/etc/httpd/conf.modules.d \
     HTTPD_MAIN_CONF_D_PATH=/etc/httpd/conf.d \
+    HTTPD_TLS_CERT_PATH=/etc/httpd/tls \
     HTTPD_VAR_RUN=/var/run/httpd \
     HTTPD_DATA_PATH=/var/www \
     HTTPD_DATA_ORIG_PATH=/opt/rh/httpd24/root/var/www \

--- a/2.4/Dockerfile.fedora
+++ b/2.4/Dockerfile.fedora
@@ -35,7 +35,7 @@ EXPOSE 8080
 EXPOSE 8443
 
 RUN dnf install -y yum-utils gettext hostname && \
-    INSTALL_PKGS="nss_wrapper bind-utils httpd mod_ssl" && \
+    INSTALL_PKGS="nss_wrapper bind-utils httpd mod_ssl openssl" && \
     dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     dnf clean all
@@ -46,6 +46,7 @@ ENV HTTPD_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/httpd/ \
     HTTPD_MAIN_CONF_PATH=/etc/httpd/conf \
     HTTPD_MAIN_CONF_MODULES_D_PATH=/etc/httpd/conf.modules.d \
     HTTPD_MAIN_CONF_D_PATH=/etc/httpd/conf.d \
+    HTTPD_TLS_CERT_PATH=/etc/httpd/tls \
     HTTPD_VAR_RUN=/var/run/httpd \
     HTTPD_DATA_PATH=/var/www \
     HTTPD_DATA_ORIG_PATH=/var/www \

--- a/2.4/Dockerfile.fedora
+++ b/2.4/Dockerfile.fedora
@@ -35,7 +35,7 @@ EXPOSE 8080
 EXPOSE 8443
 
 RUN dnf install -y yum-utils gettext hostname && \
-    INSTALL_PKGS="nss_wrapper bind-utils httpd mod_ssl openssl sscg" && \
+    INSTALL_PKGS="nss_wrapper bind-utils httpd mod_ssl sscg" && \
     dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     dnf clean all

--- a/2.4/Dockerfile.fedora
+++ b/2.4/Dockerfile.fedora
@@ -35,7 +35,7 @@ EXPOSE 8080
 EXPOSE 8443
 
 RUN dnf install -y yum-utils gettext hostname && \
-    INSTALL_PKGS="nss_wrapper bind-utils httpd mod_ssl openssl" && \
+    INSTALL_PKGS="nss_wrapper bind-utils httpd mod_ssl openssl sscg" && \
     dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     dnf clean all
@@ -57,8 +57,7 @@ COPY ./root /
 
 # Generate SSL certs and reset permissions of filesystem to default values
 # Reset permissions of filesystem to default values
-RUN /usr/libexec/httpd-ssl-gencerts && \
-    /usr/libexec/httpd-prepare && rpm-file-permissions
+RUN /usr/libexec/httpd-prepare && rpm-file-permissions
 
 USER 1001
 

--- a/2.4/Dockerfile.rhel7
+++ b/2.4/Dockerfile.rhel7
@@ -35,7 +35,7 @@ EXPOSE 8443
 
 RUN yum install -y yum-utils && \
     prepare-yum-repositories rhel-server-rhscl-7-rpms && \
-    INSTALL_PKGS="gettext hostname nss_wrapper bind-utils httpd24 httpd24-mod_ssl httpd24-mod_auth_mellon httpd24-mod_security" && \
+    INSTALL_PKGS="gettext hostname nss_wrapper bind-utils httpd24 httpd24-mod_ssl httpd24-mod_auth_mellon httpd24-mod_security openssl" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum -y clean all --enablerepo='*'
@@ -46,6 +46,7 @@ ENV HTTPD_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/httpd/ \
     HTTPD_MAIN_CONF_PATH=/etc/httpd/conf \
     HTTPD_MAIN_CONF_MODULES_D_PATH=/etc/httpd/conf.modules.d \
     HTTPD_MAIN_CONF_D_PATH=/etc/httpd/conf.d \
+    HTTPD_TLS_CERT_PATH=/etc/httpd/tls \
     HTTPD_VAR_RUN=/var/run/httpd \
     HTTPD_DATA_PATH=/var/www \
     HTTPD_DATA_ORIG_PATH=/opt/rh/httpd24/root/var/www \

--- a/2.4/Dockerfile.rhel8
+++ b/2.4/Dockerfile.rhel8
@@ -34,7 +34,7 @@ EXPOSE 8080
 EXPOSE 8443
 
 RUN yum -y module enable httpd:$HTTPD_VERSION && \
-    INSTALL_PKGS="gettext hostname nss_wrapper bind-utils httpd mod_ssl mod_auth_mellon openssl sscg" && \
+    INSTALL_PKGS="gettext hostname nss_wrapper bind-utils httpd mod_ssl mod_auth_mellon sscg" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum -y clean all --enablerepo='*'

--- a/2.4/Dockerfile.rhel8
+++ b/2.4/Dockerfile.rhel8
@@ -34,7 +34,7 @@ EXPOSE 8080
 EXPOSE 8443
 
 RUN yum -y module enable httpd:$HTTPD_VERSION && \
-    INSTALL_PKGS="gettext hostname nss_wrapper bind-utils httpd mod_ssl mod_auth_mellon" && \
+    INSTALL_PKGS="gettext hostname nss_wrapper bind-utils httpd mod_ssl mod_auth_mellon openssl" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum -y clean all --enablerepo='*'
@@ -45,6 +45,7 @@ ENV HTTPD_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/httpd/ \
     HTTPD_MAIN_CONF_PATH=/etc/httpd/conf \
     HTTPD_MAIN_CONF_MODULES_D_PATH=/etc/httpd/conf.modules.d \
     HTTPD_MAIN_CONF_D_PATH=/etc/httpd/conf.d \
+    HTTPD_TLS_CERT_PATH=/etc/httpd/tls \
     HTTPD_VAR_RUN=/var/run/httpd \
     HTTPD_DATA_PATH=/var/www \
     HTTPD_DATA_ORIG_PATH=/var/www \

--- a/2.4/Dockerfile.rhel8
+++ b/2.4/Dockerfile.rhel8
@@ -34,7 +34,7 @@ EXPOSE 8080
 EXPOSE 8443
 
 RUN yum -y module enable httpd:$HTTPD_VERSION && \
-    INSTALL_PKGS="gettext hostname nss_wrapper bind-utils httpd mod_ssl mod_auth_mellon openssl" && \
+    INSTALL_PKGS="gettext hostname nss_wrapper bind-utils httpd mod_ssl mod_auth_mellon openssl sscg" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum -y clean all --enablerepo='*'

--- a/2.4/root/usr/bin/run-httpd
+++ b/2.4/root/usr/bin/run-httpd
@@ -4,6 +4,9 @@ set -eu
 
 source ${HTTPD_CONTAINER_SCRIPTS_PATH}/common.sh
 
+# Generate TLS cert/key pair, if they dont exist
+gen_ssl_certs
+
 # Check whether we run as s2i
 if ! [ -v HTTPD_RUN_BY_S2I ] && runs_privileged ; then
   config_privileged

--- a/2.4/root/usr/bin/run-httpd
+++ b/2.4/root/usr/bin/run-httpd
@@ -4,9 +4,6 @@ set -eu
 
 source ${HTTPD_CONTAINER_SCRIPTS_PATH}/common.sh
 
-# Generate TLS cert/key pair, if they dont exist
-gen_ssl_certs
-
 # Check whether we run as s2i
 if ! [ -v HTTPD_RUN_BY_S2I ] && runs_privileged ; then
   config_privileged

--- a/2.4/root/usr/libexec/httpd-prepare
+++ b/2.4/root/usr/libexec/httpd-prepare
@@ -32,7 +32,7 @@ chown -R 1001:0 ${HTTPD_DATA_PATH}
 chmod -R g+rwx ${HTTPD_LOG_PATH}
 chown -R 1001:0 ${HTTPD_LOG_PATH}
 
-# remove bundled cert/key pair and create new dir, where we store it
+# remove bundled key pair and create new dir, where we store it
 rm -f /etc/pki/tls/certs/localhost.crt 
 rm -f /etc/pki/tls/private/localhost.key
 mkdir -p $HTTPD_TLS_CERT_PATH

--- a/2.4/root/usr/libexec/httpd-prepare
+++ b/2.4/root/usr/libexec/httpd-prepare
@@ -20,16 +20,10 @@ if [ -v HTTPD_SCL ] ; then
   ln -s /var/www /opt/rh/httpd24/root/var/www
 fi
 
-if head "/etc/redhat-release" | grep -q "^Red Hat Enterprise Linux release 8"; then
-    /usr/libexec/httpd-ssl-gencerts
-fi
-
 mkdir -p ${HTTPD_CONFIGURATION_PATH}
 chmod -R a+rwx ${HTTPD_MAIN_CONF_PATH}
 chmod -R a+rwx ${HTTPD_MAIN_CONF_D_PATH}
 chmod -R a+rwx ${HTTPD_MAIN_CONF_MODULES_D_PATH}
-chmod -R a+r   /etc/pki/tls/certs/localhost.crt
-chmod -R a+r   /etc/pki/tls/private/localhost.key
 mkdir -p ${HTTPD_APP_ROOT}/etc
 chmod -R a+rwx ${HTTPD_APP_ROOT}/etc
 chmod -R a+rwx ${HTTPD_VAR_RUN}
@@ -37,6 +31,12 @@ chown -R 1001:0 ${HTTPD_APP_ROOT}
 chown -R 1001:0 ${HTTPD_DATA_PATH}
 chmod -R g+rwx ${HTTPD_LOG_PATH}
 chown -R 1001:0 ${HTTPD_LOG_PATH}
+
+# remove bundled cert/key pair and create new dir, where we store it
+rm -f /etc/pki/tls/certs/localhost.crt 
+rm -f /etc/pki/tls/private/localhost.key
+mkdir -p $HTTPD_TLS_CERT_PATH
+chmod -R a+rwx $HTTPD_TLS_CERT_PATH
 
 mkdir -p ${HTTPD_CONTAINER_SCRIPTS_PATH}/pre-init
 

--- a/2.4/root/usr/share/container-scripts/httpd/README.md
+++ b/2.4/root/usr/share/container-scripts/httpd/README.md
@@ -111,6 +111,14 @@ You can also set the following mount points by passing the `-v /host:/container`
 directory has the appropriate permissions and that the owner and group of the directory
 matches the user UID or name which is running inside the container.**
 
+Default SSL certificates
+------------------------
+
+Default SSL certificates are generated when Apache HTTP server container is started for the first time or own SSL certificates were not provided (see bolow how to provide them). SSL certificates are not stored in the base image but generated, so each container will have unique default SSL key pair. SSL certificate/key are stored in /etc/httpd/tls directory:
+
+    /etc/httpd/tls/localhost.key
+    /etc/httpd/tls/localhost.crt
+
 
 Using own SSL certificates
 --------------------------

--- a/2.4/root/usr/share/container-scripts/httpd/common.sh
+++ b/2.4/root/usr/share/container-scripts/httpd/common.sh
@@ -20,7 +20,7 @@ gen_ssl_certs() {
     return 0
   fi
 
-  if [ -f "/etc/fedora-release" ] || ( [ -f "/etc/redhat-release" ] && [ head "/etc/redhat-release" | grep -q "^Red Hat Enterprise Linux release 8" ] ); then
+  if [ -f "/etc/fedora-release" ] || ( [ -f "/etc/redhat-release" ] && head "/etc/redhat-release" | grep -q "^Red Hat Enterprise Linux release 8" ); then
     sscg -q                                                           \
        --cert-file           $sslcert                                 \
        --cert-key-file       $sslkey                                  \

--- a/2.4/root/usr/share/container-scripts/httpd/common.sh
+++ b/2.4/root/usr/share/container-scripts/httpd/common.sh
@@ -20,7 +20,7 @@ gen_ssl_certs() {
     return 0
   fi
 
-  if [ -f "/etc/fedora-release" ] || ( [ -f "/etc/redhat-release" ] && head "/etc/redhat-release" | grep -q "^Red Hat Enterprise Linux release 8" ); then
+  if [ -x "/usr/bin/sscg" ]; then
     sscg -q                                                           \
        --cert-file           $sslcert                                 \
        --cert-key-file       $sslkey                                  \
@@ -77,8 +77,8 @@ config_privileged() {
   chmod 755 ${HTTPD_MAIN_CONF_D_PATH} && \
   chmod 644 ${HTTPD_MAIN_CONF_MODULES_D_PATH}/* && \
   chmod 755 ${HTTPD_MAIN_CONF_MODULES_D_PATH} && \
-  chmod 600 /etc/pki/tls/certs/localhost.crt && \
-  chmod 600 /etc/pki/tls/private/localhost.key && \
+  chmod 600 ${HTTPD_TLS_CERT_PATH}/localhost.crt && \
+  chmod 600 ${HTTPD_TLS_CERT_PATH}/localhost.key && \
   chmod 710 ${HTTPD_VAR_RUN}
 
   if ! [ -v HTTPD_LOG_TO_VOLUME ] ; then

--- a/2.4/root/usr/share/container-scripts/httpd/common.sh
+++ b/2.4/root/usr/share/container-scripts/httpd/common.sh
@@ -20,6 +20,7 @@ gen_ssl_certs() {
     return 0
   fi
 
+  echo "---> Generating SSL key pair for httpd..."
   if [ -x "/usr/bin/sscg" ]; then
     sscg -q                                                           \
        --cert-file           $sslcert                                 \
@@ -195,7 +196,12 @@ process_ssl_certs() {
         echo "---> Removing SSL key file settings for httpd..."
         sed -i '/^SSLCertificateKeyFile .*/d'  ${HTTPD_MAIN_CONF_D_PATH}/ssl.conf
       fi
+    else
+      # Generate TLS key pair if no SSL cert was found
+      gen_ssl_certs
     fi
+  else
+    gen_ssl_certs
   fi
 }
 


### PR DESCRIPTION
…rate cert and key

if it doesn't exist and store them in /etc/httpd/tls, since in entrypoint script we
don't have write permissions for /etc/pki/tls/...

rhbz: #1687922