### PR TITLE
[WIP] Use refactored functions and enable testing in remote OCP4

### DIFF
--- a/2.4/test/imagestreams
+++ b/2.4/test/imagestreams
@@ -1,0 +1,1 @@
+../../imagestreams/

--- a/test/imagestreams
+++ b/test/imagestreams
@@ -1,0 +1,1 @@
+../imagestreams/

--- a/test/run-openshift-local-cluster
+++ b/test/run-openshift-local-cluster
@@ -10,13 +10,17 @@ THISDIR=$(dirname ${BASH_SOURCE[0]})
 
 source "${THISDIR}/test-lib.sh"
 source "${THISDIR}/test-lib-openshift.sh"
+source "${THISDIR}/test-lib-httpd.sh"
 
 BRANCH_TO_TEST=master
 
 set -eo nounset
 
-test -n "${IMAGE_NAME-}" || false 'make sure $IMAGE_NAME is defined'
-test -n "${VERSION-}" || false 'make sure $VERSION is defined'
+trap ct_os_cleanup EXIT SIGINT
+
+ct_os_check_compulsory_vars
+
+ct_os_enable_print_logs
 
 ct_os_cluster_up
 
@@ -32,4 +36,13 @@ ct_os_test_template_app "${IMAGE_NAME}" \
                         httpd \
                         'Welcome to your static httpd application on OpenShift' \
                         8080 http 200 "-p SOURCE_REPOSITORY_REF=${BRANCH_TO_TEST} -p NAME=httpd-testing"
+
+# Check the imagestream
+test_httpd_imagestream
+
+OS_TESTSUITE_RESULT=0
+
+ct_os_cluster_down
+
+# vim: set tabstop=2:shiftwidth=2:expandtab:
 

--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -24,7 +24,12 @@ export CT_SKIP_NEW_PROJECT=true
 export CT_SKIP_UPLOAD_IMAGE=true
 export CT_NAMESPACE=openshift
 
-test_httpd_integration httpd ${VERSION} "${IMAGE_NAME}"
+test_httpd_integration "${IMAGE_NAME}" ${VERSION} httpd
+
+# Check the imagestream
+test_httpd_imagestream
 
 OS_TESTSUITE_RESULT=0
+
+# vim: set tabstop=2:shiftwidth=2:expandtab:
 

--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -24,7 +24,7 @@ export CT_SKIP_NEW_PROJECT=true
 export CT_SKIP_UPLOAD_IMAGE=true
 export CT_NAMESPACE=openshift
 
-test_httpd_integration "${IMAGE_NAME}" ${VERSION} httpd
+test_httpd_integration "${IMAGE_NAME}"
 
 # Check the imagestream
 test_httpd_imagestream

--- a/test/test-lib-httpd.sh
+++ b/test/test-lib-httpd.sh
@@ -13,13 +13,10 @@ source ${THISDIR}/test-lib-openshift.sh
 
 function test_httpd_integration() {
   local image_name=$1
-  local version=$2
-  local import_image=$3
-  VERSION=$version ct_os_test_s2i_app "${image_name}" \
-                                      "https://github.com/sclorg/httpd-container.git" \
-                                      examples/sample-test-app \
-                                      "This is a sample s2i application with static content" \
-                                      8080 http 200
+  ct_os_test_s2i_app "${image_name}" \
+                     "https://github.com/sclorg/httpd-container.git" \
+                     "examples/sample-test-app" \
+                     "This is a sample s2i application with static content"
 }
 
 # Check the imagestream

--- a/test/test-lib-httpd.sh
+++ b/test/test-lib-httpd.sh
@@ -19,8 +19,20 @@ function test_httpd_integration() {
                                       "https://github.com/sclorg/httpd-container.git" \
                                       examples/sample-test-app \
                                       "This is a sample s2i application with static content" \
-                                      8080 http 200 "" \
-                                      "${import_image}"
+                                      8080 http 200
+}
+
+# Check the imagestream
+function test_httpd_imagestream() {
+  case ${OS} in
+    rhel7|centos7) ;;
+    *) echo "Imagestream testing not supported for $OS environment." ; return 0 ;;
+  esac
+
+  ct_os_test_image_stream_s2i "${THISDIR}/imagestreams/httpd-${OS}.json" "${IMAGE_NAME}" \
+                              "https://github.com/sclorg/httpd-container.git" \
+                              "examples/sample-test-app" \
+                              "This is a sample s2i application with static content"
 }
 
 # vim: set tabstop=2:shiftwidth=2:expandtab:


### PR DESCRIPTION
This PR combines more changes:

- add image stream test
- adopts new functions refactored in https://github.com/sclorg/container-common-scripts/pull/155/files
- enables tests to be run in a remote OCP4 cluster