### PR TITLE
Fix podman output

### DIFF
--- a/2.4/test/run
+++ b/2.4/test/run
@@ -10,7 +10,7 @@ test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
 . "$test_dir/test-lib.sh"
 
 function _container_is_scl() {
-  docker inspect --format='{{.ContainerConfig.Env}}' "${1-$IMAGE_NAME}" | grep -q HTTPD_SCL
+  docker inspect --format='{{.Config.Env}}' "${1-$IMAGE_NAME}" | grep -q HTTPD_SCL
   return $?
 }
 


### PR DESCRIPTION
This commit fixes problem with getting information from Config.

On the RHEL-7 machine the output of docker inspect looks like - `docker version` is `1.13.1`:
```bash
[
    {
.. sniped ..
        "ContainerConfig": {
.. sniped ..
            "Env": [
.. sniped ..
                "HTTPD_VERSION=2.4",
                "HTTPD_VAR_RUN=/var/run/httpd",
                "HTTPD_DATA_PATH=/var/www",
                "HTTPD_DATA_ORIG_PATH=/opt/rh/httpd24/root/var/www",
                "HTTPD_LOG_PATH=/var/log/httpd24",
                "HTTPD_SCL=httpd24"
            ],
.. sniped ..
        "Config": {
.. sniped ..
            "Env": [
.. sniped ..
                "HTTPD_VERSION=2.4",
                "HTTPD_DATA_ORIG_PATH=/opt/rh/httpd24/root/var/www",
                "HTTPD_LOG_PATH=/var/log/httpd24",
                "HTTPD_SCL=httpd24"
            ],
.. sniped ..
]
```
On the RHEL-8 machine the output of docker inspect looks like - `docker/podman version` is `1.6.4` :
```bash
[
    {
.. sniped ..
        "Config": {
.. sniped ..
            "Env": [
.. sniped .. 
                "HTTPD_VERSION=2.4",
                "HTTPD_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/httpd/",
                "HTTPD_APP_ROOT=/opt/app-root",
                "HTTPD_CONFIGURATION_PATH=/opt/app-root/etc/httpd.d",
                "HTTPD_MAIN_CONF_PATH=/etc/httpd/conf",
                "HTTPD_MAIN_CONF_MODULES_D_PATH=/etc/httpd/conf.modules.d",
                "HTTPD_MAIN_CONF_D_PATH=/etc/httpd/conf.d",
                "HTTPD_TLS_CERT_PATH=/etc/httpd/tls",
                "HTTPD_VAR_RUN=/var/run/httpd",
                "HTTPD_DATA_PATH=/var/www",
                "HTTPD_DATA_ORIG_PATH=/opt/rh/httpd24/root/var/www",
                "HTTPD_LOG_PATH=/var/log/httpd24",
                "HTTPD_SCL=httpd24"
            ],
.. sniped ..
]
```


https://stackoverflow.com/questions/36216220/what-is-different-of-config-and-containerconfig-of-docker-inspect