### PR TITLE
Support testing under OpenShift 4

### DIFF
--- a/2.4/test/test-lib-remote-openshift.sh
+++ b/2.4/test/test-lib-remote-openshift.sh
@@ -1,0 +1,1 @@
+../../common/test-lib-remote-openshift.sh

--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -11,8 +11,11 @@
 THISDIR=$(dirname ${BASH_SOURCE[0]})
 
 source ${THISDIR}/test-lib-httpd.sh
+source ${THISDIR}/test-lib-remote-openshift.sh
 
 set -eo nounset
+
+ct_os_set_ocp4
 
 trap ct_os_cleanup EXIT SIGINT
 
@@ -20,9 +23,8 @@ ct_os_check_compulsory_vars
 
 oc status || false "It looks like oc is not properly logged in."
 
-export CT_SKIP_NEW_PROJECT=true
-export CT_SKIP_UPLOAD_IMAGE=true
-export CT_NAMESPACE=openshift
+# For testing on OpenShift 4 we use external registry
+export CT_EXTERNAL_REGISTRY=true
 
 test_httpd_integration "${IMAGE_NAME}"
 

--- a/test/test-lib-remote-openshift.sh
+++ b/test/test-lib-remote-openshift.sh
@@ -1,0 +1,1 @@
+../common/test-lib-remote-openshift.sh


### PR DESCRIPTION
This commit adds support for testing httpd-container under OpenShift 4 environment.

Just tag PR with [test-openshift-4]