### PR TITLE
tests: fix expected content across RHEL versions

### DIFF
--- a/2.4/test/run
+++ b/2.4/test/run
@@ -38,14 +38,14 @@ function run_default_page_test() {
   # Check default page
   run "ct_create_container test_default_page"
   cip=$(ct_get_cip 'test_default_page')
-  run "ct_test_response '${cip}':8080 403 'Test Page for the Apache HTTP Server on' 50"
+  run "ct_test_response '${cip}':8080 403 'Test Page for the (Apache )?HTTP Server on' 50"
 }
 
 function run_as_root_test() {
   # Try running as root
   CONTAINER_ARGS="--user 0" run "ct_create_container test_run_as_root"
   cip=$(ct_get_cip 'test_run_as_root')
-  run "ct_test_response '${cip}':8080 403 'Test Page for the Apache HTTP Server on'"
+  run "ct_test_response '${cip}':8080 403 'Test Page for the (Apache )?HTTP Server on'"
 }
 
 


### PR DESCRIPTION
In one of the newer RHEL8 releases the test page content will be generalized and synced between httpd and nginx, essentially removing any mentions of "Apache" from the title
RHSCL version will stay unchanged