### PR TITLE
Bug #1993439 - Change search depth to run scripts provided via ConfigMap

### DIFF
--- a/2.4/Dockerfile.rhel8
+++ b/2.4/Dockerfile.rhel8
@@ -1,4 +1,4 @@
-FROM ubi8/s2i-core:1
+FROM registry.access.redhat.com/ubi8/s2i-core:1
 
 # Apache HTTP Server image.
 #

--- a/2.4/root/usr/share/container-scripts/httpd/common.sh
+++ b/2.4/root/usr/share/container-scripts/httpd/common.sh
@@ -120,7 +120,7 @@ function get_matched_files() {
   default_dir="$2"
   files_matched="$3"
   find "$default_dir" -maxdepth 1 -type f -name "$files_matched" -printf "%f\n"
-  [ -d "$custom_dir" ] && find "$custom_dir" -maxdepth 1 -type f -name "$files_matched" -printf "%f\n"
+  [ -d "$custom_dir" ] && find "$custom_dir" -maxdepth 5 -type f -name "$files_matched" -printf "%p\n"
 }
 
 # process_extending_files process extending files in $1 and $2 directories
@@ -133,8 +133,8 @@ function process_extending_files() {
   while read filename ; do
     echo "=> sourcing $filename ..."
     # Custom file is prefered
-    if [ -f $custom_dir/$filename ]; then
-      source $custom_dir/$filename
+    if [ -f $filename ]; then
+      source $filename
     elif [ -f $default_dir/$filename ]; then 
       source $default_dir/$filename
     fi


### PR DESCRIPTION
RHBZ #1993439 changing  search to make sure we find files mounted from a ConfigMap or in sub-directories to consider them as well and run them according the process_extending_files() function. That will allow users to mount custom scripts in Kubernetes via ConfigMap and thus prevent specific builds to add the necessary scripts.