### PR TITLE
Add tag into template

### DIFF
--- a/.github/workflows/openshift-tests.yml
+++ b/.github/workflows/openshift-tests.yml
@@ -15,7 +15,7 @@ jobs:
         include:
           - tmt_plan: "centos7"
             os_test: "centos7"
-            context: "CentOS7 - OpenShift3"
+            context: "CentOS7 - OpenShift 3"
             compose: "CentOS-7"
             tmt_url: "http://artifacts.dev.testing-farm.io/"
             tmt_repo: "https://github.com/sclorg/sclorg-testing-farm"

--- a/test/run-openshift-local-cluster
+++ b/test/run-openshift-local-cluster
@@ -38,12 +38,15 @@ ct_os_test_s2i_app "${IMAGE_NAME}" "${THISDIR}/sample-test-app" . 'This is a sam
 # test remote example app
 ct_os_test_s2i_app "${IMAGE_NAME}" "https://github.com/sclorg/httpd-ex#${BRANCH_TO_TEST}" . 'Welcome to your static httpd application on OpenShift'
 
-# test template from the example app
-ct_os_test_template_app "${IMAGE_NAME}" \
-                        "https://raw.githubusercontent.com/openshift/httpd-ex/${BRANCH_TO_TEST}/openshift/templates/httpd.json" \
-                        httpd \
-                        'Welcome to your static httpd application on OpenShift' \
-                        8080 http 200 "-p SOURCE_REPOSITORY_REF=${BRANCH_TO_TEST} -p NAME=httpd-testing"
+if [ "${OS}" == "rhel8" ]; then
+  # test template from the example app
+  # Template was moved to RHEL8
+  ct_os_test_template_app "${IMAGE_NAME}" \
+                          "https://raw.githubusercontent.com/openshift/httpd-ex/${BRANCH_TO_TEST}/openshift/templates/httpd.json" \
+                          httpd \
+                          'Welcome to your static httpd application on OpenShift' \
+                          8080 http 200 "-p SOURCE_REPOSITORY_REF=${BRANCH_TO_TEST} -p NAME=httpd-testing"
+fi
 
 # Check the imagestream
 test_httpd_imagestream


### PR DESCRIPTION
Test `ct_os_test_template_app` is run only for RHEL8.

httpd-ex container https://raw.githubusercontent.com/openshift/httpd-ex/${BRANCH_TO_TEST}/openshift/templates/httpd.json uses httpd.json file which contains only RHEL8 images. It does not make sense to test it on RHEL7.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>