### PR TITLE
[APPSVC-990] Use groupified apiVersion

### DIFF
--- a/imagestreams/httpd-centos.json
+++ b/imagestreams/httpd-centos.json
@@ -1,5 +1,5 @@
 {
-  "apiVersion": "v1",
+  "apiVersion": "image.openshift.io/v1",
   "kind": "ImageStream",
   "metadata": {
     "annotations": {

--- a/imagestreams/httpd-rhel-aarch64.json
+++ b/imagestreams/httpd-rhel-aarch64.json
@@ -1,5 +1,5 @@
 {
-  "apiVersion": "v1",
+  "apiVersion": "image.openshift.io/v1",
   "kind": "ImageStream",
   "metadata": {
     "annotations": {

--- a/imagestreams/httpd-rhel.json
+++ b/imagestreams/httpd-rhel.json
@@ -1,5 +1,5 @@
 {
-  "apiVersion": "v1",
+  "apiVersion": "image.openshift.io/v1",
   "kind": "ImageStream",
   "metadata": {
     "annotations": {


### PR DESCRIPTION
Non-groupified objects were deprecated in OCP 4.7.
