### PR TITLE
Support build and testing httpd-container in CentOS Stream 9

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -64,7 +64,7 @@ jobs:
           tags: latest ${{ matrix.tag }} ${{ github.sha }}
 
       - name: Push image to Quay.io/${{ matrix.registry_namespace }} namespace
-        if: steps.check_exclude_file.outputs.files_exists == 'false' and ${{ matrix.registry_namespace == 'centos7' }}
+        if: ${{ steps.check_exclude_file.outputs.files_exists == 'false' && matrix.registry_namespace == 'centos7' }}
         id: push-to-quay-centos7
         uses: redhat-actions/push-to-registry@v2.2
         with:
@@ -75,7 +75,7 @@ jobs:
           password: ${{ secrets.QUAY_IMAGE_BUILDER_TOKEN }}
 
       - name: Push image to Quay.io/${{ matrix.registry_namespace }} namespace
-        if: steps.check_exclude_file.outputs.files_exists == 'false' and ${{ matrix.registry_namespace != 'centos7' }}
+        if: ${{ steps.check_exclude_file.outputs.files_exists == 'false' && ${{ matrix.registry_namespace != 'centos7' }}
         id: push-to-quay-sclorg
         uses: redhat-actions/push-to-registry@v2.2
         with:

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -8,8 +8,17 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        version: [2.4]
+        version: "2.4"
+        include:
+          - dockerfile: "Dockerfile"
+            registry_namespace: "centos7"
+            tag: "centos7"
+          - dockerfile: "Dockerfile.c9s"
+            registry_namespace: "sclorg"
+            tag: "c9s"
+
     steps:
       - uses: actions/checkout@v2
 
@@ -28,34 +37,58 @@ jobs:
           ver="${{ matrix.version }}"
           echo "::set-output name=SHORT_VER::${ver//./}"
 
-      - name: Check if .exclude-centos7 is present in version directory
-        id: check_exclude_centos7_file
+      - name: Login to Quay.io private registry
+        if: ${{ matrix.registry_namespace != 'centos7' }}
+        uses: redhat-actions/podman-login@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_IMAGE_SCLORG_BUILDER_USERNAME }}
+          password: ${{ secrets.QUAY_IMAGE_SCLORG_BUILDER_TOKEN }}
+
+      - name: Check if .exclude-${{ matrix.tag }} is present in version directory
+        id: check_exclude_file
         # https://github.com/marketplace/actions/file-existence
         uses: andstor/file-existence-action@v1
         with:
-          files: "${{ matrix.version }}/.exclude-centos7"
+          files: "${{ matrix.version }}/.exclude-${{ matrix.tag }}"
 
-      - name: Build CentOS7 image
-        if: steps.check_exclude_centos7_file.outputs.files_exists == 'false'
+      - name: Build image
+        if: steps.check_exclude_file.outputs.files_exists == 'false'
         id: build-image
         # https://github.com/marketplace/actions/buildah-build
         uses: redhat-actions/buildah-build@v2
         with:
-          dockerfiles: ${{ matrix.version }}/Dockerfile
-          image: ${{ steps.base-image-name.outputs.image_name}}-${{ steps.short_version.outputs.SHORT_VER }}-centos7
+          dockerfiles: ${{ matrix.version }}/${{ matrix.dockerfile }}
+          image: ${{ steps.base-image-name.outputs.image_name}}-${{ steps.short_version.outputs.SHORT_VER }}-${{ matrix.tag }}
           context: ${{ matrix.version }}
-          tags: latest 1 ${{ github.sha }}
+          tags: latest ${{ matrix.tag }} ${{ github.sha }}
 
-      - name: Push CentOS7 image to Quay.io
-        if: steps.check_exclude_centos7_file.outputs.files_exists == 'false'
-        id: push-to-quay
+      - name: Push image to Quay.io/${{ matrix.registry_namespace }} namespace
+        if: steps.check_exclude_file.outputs.files_exists == 'false' and ${{ matrix.registry_namespace == 'centos7' }}
+        id: push-to-quay-centos7
         uses: redhat-actions/push-to-registry@v2.2
         with:
           image: ${{ steps.build-image.outputs.image }}
           tags: ${{ steps.build-image.outputs.tags }}
-          registry: quay.io/centos7
+          registry: quay.io/${{ matrix.registry_namespace }}
           username: ${{ secrets.QUAY_IMAGE_BUILDER_USERNAME }}
           password: ${{ secrets.QUAY_IMAGE_BUILDER_TOKEN }}
 
+      - name: Push image to Quay.io/${{ matrix.registry_namespace }} namespace
+        if: steps.check_exclude_file.outputs.files_exists == 'false' and ${{ matrix.registry_namespace != 'centos7' }}
+        id: push-to-quay-sclorg
+        uses: redhat-actions/push-to-registry@v2.2
+        with:
+          image: ${{ steps.build-image.outputs.image }}
+          tags: ${{ steps.build-image.outputs.tags }}
+          registry: quay.io/${{ matrix.registry_namespace }}
+          username: ${{ secrets.QUAY_IMAGE_SCLORG_BUILDER_USERNAME }}
+          password: ${{ secrets.QUAY_IMAGE_SCLORG_BUILDER_TOKEN  }}
+
       - name: Print image url
-        run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
+        if: ${{ matrix.registry_namespace == 'centos7' }}
+        run: echo "Image pushed to ${{ steps.push-to-quay-centos7.outputs.registry-paths }}"
+
+      - name: Print image url
+        if: ${{ matrix.registry_namespace != 'centos7' }}
+        run: echo "Image pushed to ${{ steps.push-to-quay-sclorg.outputs.registry-paths }}"

--- a/2.4/Dockerfile.c9s
+++ b/2.4/Dockerfile.c9s
@@ -1,0 +1,66 @@
+FROM quay.io/sclorg/s2i-core-c9s:c9s
+
+# Apache HTTP Server image.
+#
+# Volumes:
+#  * /var/www - Datastore for httpd
+#  * /var/log/httpd24 - Storage for logs when $HTTPD_LOG_TO_VOLUME is set
+# Environment:
+#  * $HTTPD_LOG_TO_VOLUME (optional) - When set, httpd will log into /var/log/httpd24
+
+ENV HTTPD_VERSION=2.4
+
+ENV SUMMARY="Platform for running Apache httpd $HTTPD_VERSION or building httpd-based application" \
+    DESCRIPTION="Apache httpd $HTTPD_VERSION available as container, is a powerful, efficient, \
+and extensible web server. Apache supports a variety of features, many implemented as compiled modules \
+which extend the core functionality. \
+These can range from server-side programming language support to authentication schemes. \
+Virtual hosting allows one Apache installation to serve many different Web sites."
+
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="Apache httpd $HTTPD_VERSION" \
+      io.openshift.expose-services="8080:http,8443:https" \
+      io.openshift.tags="builder,httpd,httpd-24" \
+      name="sclorg/httpd-24-c9s" \
+      version="1" \
+      com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
+      com.redhat.component="httpd-24-container" \
+      usage="s2i build https://github.com/sclorg/httpd-container.git --context-dir=examples/sample-test-app/ quay.io/sclorg/httpd-24-c9s sample-server" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
+
+EXPOSE 8080
+EXPOSE 8443
+
+RUN INSTALL_PKGS="gettext hostname nss_wrapper bind-utils httpd mod_ssl mod_ldap mod_session mod_security mod_auth_mellon sscg" && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum -y clean all --enablerepo='*'
+
+ENV HTTPD_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/httpd/ \
+    HTTPD_APP_ROOT=${APP_ROOT} \
+    HTTPD_CONFIGURATION_PATH=${APP_ROOT}/etc/httpd.d \
+    HTTPD_MAIN_CONF_PATH=/etc/httpd/conf \
+    HTTPD_MAIN_CONF_MODULES_D_PATH=/etc/httpd/conf.modules.d \
+    HTTPD_MAIN_CONF_D_PATH=/etc/httpd/conf.d \
+    HTTPD_TLS_CERT_PATH=/etc/httpd/tls \
+    HTTPD_VAR_RUN=/var/run/httpd \
+    HTTPD_DATA_PATH=/var/www \
+    HTTPD_DATA_ORIG_PATH=/var/www \
+    HTTPD_LOG_PATH=/var/log/httpd
+
+COPY ./s2i/bin/ $STI_SCRIPTS_PATH
+COPY ./root /
+
+# Reset permissions of filesystem to default values
+RUN /usr/libexec/httpd-prepare && rpm-file-permissions
+
+USER 1001
+
+# Not using VOLUME statement since it's not working in OpenShift Online:
+# https://github.com/sclorg/httpd-container/issues/30
+# VOLUME ["${HTTPD_DATA_PATH}"]
+# VOLUME ["${HTTPD_LOG_PATH}"]
+
+CMD ["/usr/bin/run-httpd"]

--- a/2.4/root/usr/share/container-scripts/httpd/common.sh
+++ b/2.4/root/usr/share/container-scripts/httpd/common.sh
@@ -2,6 +2,8 @@
 
 if head "/etc/redhat-release" | grep -q "^Red Hat Enterprise Linux release 8"; then
   HTTPCONF_LINENO=154
+elif [ "x$PLATFORM" == "xel9" ]; then
+  HTTPCONF_LINENO=156
 else
   HTTPCONF_LINENO=151
 fi

--- a/2.4/test/run
+++ b/2.4/test/run
@@ -38,14 +38,22 @@ function run_default_page_test() {
   # Check default page
   run "ct_create_container test_default_page"
   cip=$(ct_get_cip 'test_default_page')
-  run "ct_test_response '${cip}':8080 403 'Test Page for the (Apache )?HTTP Server on' 50"
+  if [[ "${OS}" == "c9s" ]]; then
+    run "ct_test_response '${cip}':8080 403 'HTTP Server Test Page' 50"
+  else
+    run "ct_test_response '${cip}':8080 403 'Test Page for the (Apache )?HTTP Server on' 50"
+  fi
 }
 
 function run_as_root_test() {
   # Try running as root
   CONTAINER_ARGS="--user 0" run "ct_create_container test_run_as_root"
   cip=$(ct_get_cip 'test_run_as_root')
-  run "ct_test_response '${cip}':8080 403 'Test Page for the (Apache )?HTTP Server on'"
+  if [[ "${OS}" == "c9s" ]]; then
+    run "ct_test_response '${cip}':8080 403 'HTTP Server Test Page'"
+  else
+    run "ct_test_response '${cip}':8080 403 'Test Page for the (Apache )?HTTP Server on'"
+  fi
 }
 
 


### PR DESCRIPTION
This pull request adds support for testing httpd-container in CentOS Stream 9.

The `2.4/Dockerfile.c9s` is added to support building and testing CentOS Stream 9.
Also, build-and-push.yml is updated to push 2.4 httpd-container to Quay.io/centos7 and quay.io/sclorg organization.

Dockerfile.rhel8 and Dockerfile.c9s difference:
```bash
$ diff 2.4/Dockerfile.rhel8 2.4/Dockerfile.c9s
1c1
< FROM ubi8/s2i-core:1
---
> FROM quay.io/sclorg/s2i-core-c9s:c9s
26c26
<       name="rhel8/httpd-24" \
---
>       name="sclorg/httpd-24-c9s" \
30c30
<       usage="s2i build https://github.com/sclorg/httpd-container.git --context-dir=examples/sample-test-app/ rhel8/httpd-24 sample-server" \
---
>       usage="s2i build https://github.com/sclorg/httpd-container.git --context-dir=examples/sample-test-app/ quay.io/sclorg/httpd-24-c9s sample-server" \
36,37c36
< RUN yum -y module enable httpd:$HTTPD_VERSION && \
<     INSTALL_PKGS="gettext hostname nss_wrapper bind-utils httpd mod_ssl mod_ldap mod_session mod_security mod_auth_mellon sscg" && \
---
> RUN INSTALL_PKGS="gettext hostname nss_wrapper bind-utils httpd mod_ssl mod_ldap mod_session mod_security mod_auth_mellon sscg" && \
```
