### PR TITLE
Test certificates age, so we are sure the certificates were just generated during assemble script

### DIFF
--- a/test/run
+++ b/test/run
@@ -131,6 +131,27 @@ function run_s2i_test() {
   CONTAINER_ARGS='--user 1000' IMAGE_NAME=${IMAGE_NAME}-testapp ct_create_container testing-app-s2i
   cip=$(ct_get_cip 'testing-app-s2i')
   run "ct_test_response '${cip}:8080' 200 'This is a sample s2i application with static content.'"
+
+  # Let's see whether the automatically generated certificate works as expected
+  run "curl -k https://${cip}:8443 >output_generated_ssl_cert"
+  run "fgrep -e 'This is a sample s2i application with static content.' output_generated_ssl_cert"
+}
+
+function run_cert_age_test() {
+  run "ct_s2i_build_as_df file://${test_dir}/sample-test-app ${IMAGE_NAME} ${IMAGE_NAME}-cert-age ${s2i_args}" 0 "Testing 's2i build for cert age'"
+  CONTAINER_ARGS='--user 1000' IMAGE_NAME=${IMAGE_NAME}-cert-age ct_create_container testing-cert-age
+  # We need to make sure the certificate is generated no sooner than in assemble phase,
+  # because shipping the same certs in the image would make it easy to exploit
+  # Let's see how old the certificate is and compare with how old the image is
+  image_age_s=$(ct_get_image_age_s "${IMAGE_NAME}")
+  certificate_age_s=$(ct_get_certificate_age_s $(ct_get_cid testing-cert-age) '$HTTPD_TLS_CERT_PATH/localhost.crt')
+  run "test '$certificate_age_s' -lt '$image_age_s'" 0 "Testing whether the certificate was freshly generated after the image"
+
+  # Let's also check whether the certificates are where we expect them and were not
+  # in the original production image
+  run "docker run --rm ${IMAGE_NAME} bash -c 'test -e \$HTTPD_TLS_CERT_PATH/localhost.crt'" 1 "Testing of not presence of a certificate in the production image"
+  run "docker exec $(ct_get_cid testing-cert-age) bash -c 'ls -l \$HTTPD_TLS_CERT_PATH/localhost.crt'" 0 "Testing presence and permissions of the generated certificate"
+  run "docker exec $(ct_get_cid testing-cert-age) bash -c 'ls -l \$HTTPD_TLS_CERT_PATH/localhost.key'" 0 "Testing presence and permissions of the generated certificate"
 }
 
 function run_pre_init_test() {
@@ -178,6 +199,7 @@ run_as_root_test
 run_log_to_volume_test
 run_data_volume_test
 run_s2i_test
+run_cert_age_test
 run_pre_init_test
 run_mpm_config_test
 run_dockerfiles_test


### PR DESCRIPTION
**WARNING**: This PR requires https://github.com/sclorg/container-common-scripts/pull/245 to be merged first.

<!-- issue-commentator = {"comment-id":"2373247342"} -->











































































































<!-- testing-farm = {"lock":"false","comment-id":"2461717202","data":[{"id":"2c98301d-c8c4-45c2-b7d4-3642046d5334","name":"CentOS Stream 9 - 2.4","status":"complete","outcome":"passed","runTime":3496.363647,"created":"2024-11-07T10:43:25.728031","updated":"2024-11-07T10:43:25.728038","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/2c98301d-c8c4-45c2-b7d4-3642046d5334\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/2c98301d-c8c4-45c2-b7d4-3642046d5334/pipeline.log\">pipeline</a>"]},{"id":"093e7bcf-3a97-4ce4-a9ee-4e5dacfabce9","name":"CentOS Stream 9 - 2.4-micro","status":"complete","outcome":"passed","runTime":3508.068708,"created":"2024-11-07T10:43:25.818973","updated":"2024-11-07T10:43:25.818980","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/093e7bcf-3a97-4ce4-a9ee-4e5dacfabce9\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/093e7bcf-3a97-4ce4-a9ee-4e5dacfabce9/pipeline.log\">pipeline</a>"]},{"id":"07f57231-ba7a-4dc4-80fe-6ddcf8a5772c","name":"CentOS Stream 10 - 2.4","status":"complete","outcome":"passed","runTime":3709.302957,"created":"2024-11-07T10:43:28.956954","updated":"2024-11-07T10:43:28.956960","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/07f57231-ba7a-4dc4-80fe-6ddcf8a5772c\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/07f57231-ba7a-4dc4-80fe-6ddcf8a5772c/pipeline.log\">pipeline</a>"]},{"id":"5b3dfc81-e25a-4e25-9d09-a8a239be50ca","name":"Fedora - 2.4","status":"complete","outcome":"passed","runTime":3709.543936,"created":"2024-11-07T10:43:28.472323","updated":"2024-11-07T10:43:28.472331","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/5b3dfc81-e25a-4e25-9d09-a8a239be50ca\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/5b3dfc81-e25a-4e25-9d09-a8a239be50ca/pipeline.log\">pipeline</a>"]},{"id":"70ce9acc-8170-453c-96a1-ca02b6c87c6e","name":"CentOS Stream 10 - 2.4-micro","status":"complete","outcome":"passed","runTime":3720.063173,"created":"2024-11-07T10:43:26.888771","updated":"2024-11-07T10:43:26.888778","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/70ce9acc-8170-453c-96a1-ca02b6c87c6e\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/70ce9acc-8170-453c-96a1-ca02b6c87c6e/pipeline.log\">pipeline</a>"]},{"id":"c769c78a-4729-4c57-9464-9388e80934fc","name":"Fedora - 2.4-micro","status":"complete","outcome":"passed","runTime":3684.669324,"created":"2024-11-07T10:43:26.629045","updated":"2024-11-07T10:43:26.629052","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/c769c78a-4729-4c57-9464-9388e80934fc\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/c769c78a-4729-4c57-9464-9388e80934fc/pipeline.log\">pipeline</a>"]},{"id":"df499f29-ae43-47e7-815c-a328701252f5","name":"RHEL9 - 2.4","status":"complete","outcome":"passed","runTime":4145.79092,"created":"2024-11-07T10:43:28.989071","updated":"2024-11-07T10:43:28.989077","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/df499f29-ae43-47e7-815c-a328701252f5\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/df499f29-ae43-47e7-815c-a328701252f5/pipeline.log\">pipeline</a>"]},{"id":"c215913b-34ea-4b66-81d9-548d702ed75a","name":"RHEL9 - OpenShift 4 - 2.4","status":"complete","outcome":"passed","runTime":4318.576469,"created":"2024-11-07T10:43:47.996432","updated":"2024-11-07T10:43:47.996439","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c215913b-34ea-4b66-81d9-548d702ed75a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c215913b-34ea-4b66-81d9-548d702ed75a/pipeline.log\">pipeline</a>"]},{"id":"210919e8-143c-4ea4-9d35-6c8ffce7655b","name":"RHEL8 - 2.4","status":"complete","outcome":"passed","runTime":4355.047498,"created":"2024-11-07T10:43:26.905207","updated":"2024-11-07T10:43:26.905213","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/210919e8-143c-4ea4-9d35-6c8ffce7655b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/210919e8-143c-4ea4-9d35-6c8ffce7655b/pipeline.log\">pipeline</a>"]},{"id":"c2aac9cb-ca7b-475c-b262-325420bdee03","name":"RHEL8 - OpenShift 4 - 2.4","status":"complete","outcome":"passed","runTime":4456.780538,"created":"2024-11-07T10:43:45.396483","updated":"2024-11-07T10:43:45.396492","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c2aac9cb-ca7b-475c-b262-325420bdee03\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c2aac9cb-ca7b-475c-b262-325420bdee03/pipeline.log\">pipeline</a>"]},{"id":"3bf7eeea-e922-44a6-b112-e256d99d5582","name":"RHEL9 - PyTest - OpenShift 4 - 2.4","status":"complete","outcome":"passed","runTime":4484.550915,"created":"2024-11-07T10:43:44.921537","updated":"2024-11-07T10:43:44.921544","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3bf7eeea-e922-44a6-b112-e256d99d5582\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3bf7eeea-e922-44a6-b112-e256d99d5582/pipeline.log\">pipeline</a>"]},{"id":"60455241-1429-456e-bc22-e8c00b1af155","name":"RHEL8 - PyTest - OpenShift 4 - 2.4","runTime":4624.990412,"created":"2024-11-07T10:43:45.740620","updated":"2024-11-07T10:43:45.740627","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/60455241-1429-456e-bc22-e8c00b1af155\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/60455241-1429-456e-bc22-e8c00b1af155/pipeline.log\">pipeline</a>"]}]} -->