### PR TITLE
Do not allow other users to read the generated SSL key/crt

### DIFF
--- a/2.4-micro/root/usr/share/container-scripts/httpd/common.sh
+++ b/2.4-micro/root/usr/share/container-scripts/httpd/common.sh
@@ -53,8 +53,8 @@ root@${fqdn}
 EOF
    fi
 
-   chmod 644 ${sslcert}
-   chmod 644 ${sslkey}
+   chmod 640 ${sslcert}
+   chmod 640 ${sslkey}
 }
 
 config_general() {

--- a/2.4/root/usr/share/container-scripts/httpd/common.sh
+++ b/2.4/root/usr/share/container-scripts/httpd/common.sh
@@ -57,8 +57,8 @@ root@${fqdn}
 EOF
    fi
 
-   chmod 640 ${sslcert}
-   chmod 640 ${sslkey}
+   chmod 640 "${sslcert}"
+   chmod 640 "${sslkey}"
 }
 
 config_general() {

--- a/2.4/root/usr/share/container-scripts/httpd/common.sh
+++ b/2.4/root/usr/share/container-scripts/httpd/common.sh
@@ -57,8 +57,8 @@ root@${fqdn}
 EOF
    fi
 
-   chmod 644 ${sslcert}
-   chmod 644 ${sslkey}
+   chmod 640 ${sslcert}
+   chmod 640 ${sslkey}
 }
 
 config_general() {


### PR DESCRIPTION
We need to maintain the feature of being able to run the container as
any user ID, so we cannot just leave the user to have read permissions
for the generated key and certificate.

However, there seems to be no use case for having the permissions
for reading for other users. While being a different user inside a container
might be not relevant anyway in the container case, let's rather be
super cautious and remove the read permissions that are not needed.

<!-- issue-commentator = {"comment-id":"2373219982"} -->

























<!-- testing-farm = {"lock":"false","comment-id":"2373272065","data":[{"id":"9b637369-f80b-4c2a-a2e3-86415b62dad3","name":"Fedora - 2.4","status":"complete","outcome":"passed","runTime":1051.201329,"created":"2024-09-25T07:08:56.294453","updated":"2024-09-25T07:08:56.294460","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/9b637369-f80b-4c2a-a2e3-86415b62dad3\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/9b637369-f80b-4c2a-a2e3-86415b62dad3/pipeline.log\">pipeline</a>"]},{"id":"2956857b-f026-4210-8f7b-6060c5c98a75","name":"CentOS Stream 9 - 2.4-micro","status":"complete","outcome":"passed","runTime":1089.852648,"created":"2024-09-25T07:08:54.464452","updated":"2024-09-25T07:08:54.464459","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/2956857b-f026-4210-8f7b-6060c5c98a75\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/2956857b-f026-4210-8f7b-6060c5c98a75/pipeline.log\">pipeline</a>"]},{"id":"3041fb3d-0d37-4d01-8322-d04aa71f5618","name":"RHEL9 - 2.4","status":"complete","outcome":"passed","runTime":1418.333451,"created":"2024-09-25T07:08:55.801532","updated":"2024-09-25T07:08:55.801538","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3041fb3d-0d37-4d01-8322-d04aa71f5618\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3041fb3d-0d37-4d01-8322-d04aa71f5618/pipeline.log\">pipeline</a>"]},{"id":"149a57ce-c3a9-4733-9426-d9e68f5fbd83","name":"RHEL8 - 2.4","runTime":1588.475601,"created":"2024-09-25T07:08:58.533837","updated":"2024-09-25T07:08:58.533846","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/149a57ce-c3a9-4733-9426-d9e68f5fbd83\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/149a57ce-c3a9-4733-9426-d9e68f5fbd83/pipeline.log\">pipeline</a>"]}]} -->