### PR TITLE
Remove version control systems from source directory

### DIFF
--- a/2.4/s2i/bin/assemble
+++ b/2.4/s2i/bin/assemble
@@ -10,6 +10,7 @@ config_s2i
 
 echo "---> Installing application source"
 cp -af /tmp/src/. ./
+rm -rf ./.hg ./.git ./.svn
 
 # Fix source directory permissions
 fix-permissions ./


### PR DESCRIPTION
When is this container used with the oc new-app command,
versioning systems are copied with the source of the application.
This could be dangerous and should be avoided.