### PR TITLE
Add ubi9 imagestream, replace el8 with ubi8

### DIFF
--- a/imagestreams/httpd-centos.json
+++ b/imagestreams/httpd-centos.json
@@ -21,12 +21,52 @@
         },
         "from": {
           "kind": "ImageStreamTag",
-          "name": "2.4-el8"
+          "name": "2.4-ubi8"
         },
         "referencePolicy": {
           "type": "Local"
         },
         "name": "latest"
+      },
+      {
+        "annotations": {
+          "description": "Build and serve static content via Apache HTTP Server (httpd) 2.4 on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/httpd-container/blob/master/2.4/README.md.",
+          "iconClass": "icon-apache",
+          "openshift.io/display-name": "Apache HTTP Server 2.4 (UBI 9)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "sampleRepo": "https://github.com/sclorg/httpd-ex.git",
+          "supports": "httpd",
+          "tags": "builder,httpd",
+          "version": "2.4"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.access.redhat.com/ubi9/httpd-24:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        },
+        "name": "2.4-ubi9"
+      },
+      {
+        "annotations": {
+          "description": "Build and serve static content via Apache HTTP Server (httpd) 2.4 on RHEL 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/httpd-container/blob/master/2.4/README.md.",
+          "iconClass": "icon-apache",
+          "openshift.io/display-name": "Apache HTTP Server 2.4 (UBI 8)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "sampleRepo": "https://github.com/sclorg/httpd-ex.git",
+          "supports": "httpd",
+          "tags": "builder,httpd",
+          "version": "2.4"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.access.redhat.com/ubi8/httpd-24:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        },
+        "name": "2.4-ubi8"
       },
       {
         "annotations": {
@@ -36,7 +76,7 @@
           "openshift.io/provider-display-name": "Red Hat, Inc.",
           "sampleRepo": "https://github.com/sclorg/httpd-ex.git",
           "supports": "httpd",
-          "tags": "builder,httpd",
+          "tags": "builder,httpd,hidden",
           "version": "2.4"
         },
         "from": {

--- a/imagestreams/httpd-rhel-aarch64.json
+++ b/imagestreams/httpd-rhel-aarch64.json
@@ -21,12 +21,52 @@
         },
         "from": {
           "kind": "ImageStreamTag",
-          "name": "2.4-el8"
+          "name": "2.4-ubi8"
         },
         "referencePolicy": {
           "type": "Local"
         },
         "name": "latest"
+      },
+      {
+        "annotations": {
+          "description": "Build and serve static content via Apache HTTP Server (httpd) 2.4 on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/httpd-container/blob/master/2.4/README.md.",
+          "iconClass": "icon-apache",
+          "openshift.io/display-name": "Apache HTTP Server 2.4 (UBI 9)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "sampleRepo": "https://github.com/sclorg/httpd-ex.git",
+          "supports": "httpd",
+          "tags": "builder,httpd",
+          "version": "2.4"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/ubi9/httpd-24:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        },
+        "name": "2.4-ubi9"
+      },
+      {
+        "annotations": {
+          "description": "Build and serve static content via Apache HTTP Server (httpd) 2.4 on RHEL 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/httpd-container/blob/master/2.4/README.md.",
+          "iconClass": "icon-apache",
+          "openshift.io/display-name": "Apache HTTP Server 2.4 (UBI 8)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "sampleRepo": "https://github.com/sclorg/httpd-ex.git",
+          "supports": "httpd",
+          "tags": "builder,httpd",
+          "version": "2.4"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/ubi8/httpd-24:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        },
+        "name": "2.4-ubi8"
       },
       {
         "annotations": {
@@ -36,7 +76,7 @@
           "openshift.io/provider-display-name": "Red Hat, Inc.",
           "sampleRepo": "https://github.com/sclorg/httpd-ex.git",
           "supports": "httpd",
-          "tags": "builder,httpd",
+          "tags": "builder,httpd,hidden",
           "version": "2.4"
         },
         "from": {

--- a/imagestreams/httpd-rhel.json
+++ b/imagestreams/httpd-rhel.json
@@ -21,12 +21,52 @@
         },
         "from": {
           "kind": "ImageStreamTag",
-          "name": "2.4-el8"
+          "name": "2.4-ubi8"
         },
         "referencePolicy": {
           "type": "Local"
         },
         "name": "latest"
+      },
+      {
+        "annotations": {
+          "description": "Build and serve static content via Apache HTTP Server (httpd) 2.4 on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/httpd-container/blob/master/2.4/README.md.",
+          "iconClass": "icon-apache",
+          "openshift.io/display-name": "Apache HTTP Server 2.4 (UBI 9)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "sampleRepo": "https://github.com/sclorg/httpd-ex.git",
+          "supports": "httpd",
+          "tags": "builder,httpd",
+          "version": "2.4"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/ubi9/httpd-24:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        },
+        "name": "2.4-ubi9"
+      },
+      {
+        "annotations": {
+          "description": "Build and serve static content via Apache HTTP Server (httpd) 2.4 on RHEL 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/httpd-container/blob/master/2.4/README.md.",
+          "iconClass": "icon-apache",
+          "openshift.io/display-name": "Apache HTTP Server 2.4 (UBI 8)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "sampleRepo": "https://github.com/sclorg/httpd-ex.git",
+          "supports": "httpd",
+          "tags": "builder,httpd",
+          "version": "2.4"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/ubi8/httpd-24:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        },
+        "name": "2.4-ubi8"
       },
       {
         "annotations": {
@@ -36,7 +76,7 @@
           "openshift.io/provider-display-name": "Red Hat, Inc.",
           "sampleRepo": "https://github.com/sclorg/httpd-ex.git",
           "supports": "httpd",
-          "tags": "builder,httpd",
+          "tags": "builder,httpd,hidden",
           "version": "2.4"
         },
         "from": {


### PR DESCRIPTION
httpd was added to UBI after the initial RHEL 8 enablement.
