### PR TITLE
Support building testing rhel9

### DIFF
--- a/2.4/Dockerfile.rhel9
+++ b/2.4/Dockerfile.rhel9
@@ -1,0 +1,66 @@
+FROM ubi9/s2i-core:1
+
+# Apache HTTP Server image.
+#
+# Volumes:
+#  * /var/www - Datastore for httpd
+#  * /var/log/httpd24 - Storage for logs when $HTTPD_LOG_TO_VOLUME is set
+# Environment:
+#  * $HTTPD_LOG_TO_VOLUME (optional) - When set, httpd will log into /var/log/httpd24
+
+ENV HTTPD_VERSION=2.4
+
+ENV SUMMARY="Platform for running Apache httpd $HTTPD_VERSION or building httpd-based application" \
+    DESCRIPTION="Apache httpd $HTTPD_VERSION available as container, is a powerful, efficient, \
+and extensible web server. Apache supports a variety of features, many implemented as compiled modules \
+which extend the core functionality. \
+These can range from server-side programming language support to authentication schemes. \
+Virtual hosting allows one Apache installation to serve many different Web sites."
+
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="Apache httpd $HTTPD_VERSION" \
+      io.openshift.expose-services="8080:http,8443:https" \
+      io.openshift.tags="builder,httpd,httpd-24" \
+      name="rhel9/httpd-24" \
+      version="1" \
+      com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
+      com.redhat.component="httpd-24-container" \
+      usage="s2i build https://github.com/sclorg/httpd-container.git --context-dir=examples/sample-test-app/ rhel9/httpd-24 sample-server" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
+
+EXPOSE 8080
+EXPOSE 8443
+
+RUN INSTALL_PKGS="gettext hostname nss_wrapper bind-utils httpd mod_ssl mod_ldap mod_session mod_security mod_auth_mellon sscg" && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum -y clean all --enablerepo='*'
+
+ENV HTTPD_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/httpd/ \
+    HTTPD_APP_ROOT=${APP_ROOT} \
+    HTTPD_CONFIGURATION_PATH=${APP_ROOT}/etc/httpd.d \
+    HTTPD_MAIN_CONF_PATH=/etc/httpd/conf \
+    HTTPD_MAIN_CONF_MODULES_D_PATH=/etc/httpd/conf.modules.d \
+    HTTPD_MAIN_CONF_D_PATH=/etc/httpd/conf.d \
+    HTTPD_TLS_CERT_PATH=/etc/httpd/tls \
+    HTTPD_VAR_RUN=/var/run/httpd \
+    HTTPD_DATA_PATH=/var/www \
+    HTTPD_DATA_ORIG_PATH=/var/www \
+    HTTPD_LOG_PATH=/var/log/httpd
+
+COPY ./s2i/bin/ $STI_SCRIPTS_PATH
+COPY ./root /
+
+# Reset permissions of filesystem to default values
+RUN /usr/libexec/httpd-prepare && rpm-file-permissions
+
+USER 1001
+
+# Not using VOLUME statement since it's not working in OpenShift Online:
+# https://github.com/sclorg/httpd-container/issues/30
+# VOLUME ["${HTTPD_DATA_PATH}"]
+# VOLUME ["${HTTPD_LOG_PATH}"]
+
+CMD ["/usr/bin/run-httpd"]

--- a/2.4/root/usr/share/container-scripts/httpd/README.md
+++ b/2.4/root/usr/share/container-scripts/httpd/README.md
@@ -5,6 +5,7 @@ This container image includes Apache HTTP Server 2.4 for OpenShift and general u
 Users can choose between RHEL, CentOS and Fedora based images.
 The RHEL images are available in the [Red Hat Container Catalog](https://access.redhat.com/containers/),
 the CentOS images are available on [Quay.io](https://quay.io/organization/centos7),
+the CentOS Stream 8 and CentOS Stream 9 images are available on [Quay.io](https://quay.io/organization/sclorg),
 and the Fedora images are available in [Fedora Registry](https://registry.fedoraproject.org/).
 The resulting image can be run using [podman](https://github.com/containers/libpod).
 
@@ -244,6 +245,7 @@ See also
 Dockerfile and other sources for this container image are available on
 https://github.com/sclorg/httpd-container.
 In that repository, the Dockerfile for CentOS7 is called Dockerfile, the Dockerfile
-for RHEL7 is called Dockerfile.rhel7, the Dockerfile for RHEL8 is called Dockerfile.rhel8, the Dockerfile
+for RHEL7 is called Dockerfile.rhel7, the Dockerfile for RHEL8 is called Dockerfile.rhel8,
+the Dockerfile for RHEL9 is called Dockerfile.rhel9, the Dockerfile
 for CentOS Stream 8 is called Dockerfile.c8s, the Dockerfile for CentOS Stream 9 is called Dockerfile.c9s,
 and the Dockerfile for Fedora is called Dockerfile.fedora.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,11 @@ Apache HTTP Server Container Images
 
 [![Build and push images to Quay.io registry](https://github.com/sclorg/httpd-container/actions/workflows/build-and-push.yml/badge.svg)](https://github.com/sclorg/httpd-container/actions/workflows/build-and-push.yml)
 
-[![Docker Repository on Quay](https://quay.io/repository/centos7/httpd-24-centos7/status "Docker Repository on Quay")](https://quay.io/repository/centos7/httpd-24-centos7)
+Images available on Quay are:
+* CentOS 7 [httpd-24](https://quay.io/repository/centos7/httpd-24-centos7)
+* CentOS Stream 8 [httpd-2.4](https://quay.io/repository/sclorg/httpd-24-c8s)
+* CentOS Stream 9 [httpd-2.4](https://quay.io/repository/sclorg/httpd-24-c9s)
+* Fedora [httpd-2.4](https://quay.io/repository/fedora/httpd-24)
 
 This repository contains Dockerfiles for Apache HTTP Server images for OpenShift and general usage.
 Users can choose between RHEL and CentOS based images.
@@ -21,6 +25,8 @@ Apache HTTPD versions currently provided are:
 
 RHEL versions currently supported are:
 * RHEL 7
+* RHEL 8
+* RHEL 9
 
 CentOS versions currently supported are:
 * CentOS 7


### PR DESCRIPTION
This pull request adds support for building, testing httpd-container on RHEL9 host.
It updates also README.md with references to `quay.io` registry.
The container-common-scripts are also updated.