### PR TITLE
micro: revert 4d6f8e0 and move from rawhide base image

### DIFF
--- a/2.4-micro/Dockerfile.fedora
+++ b/2.4-micro/Dockerfile.fedora
@@ -1,9 +1,9 @@
-FROM quay.io/fedora/fedora:rawhide AS build
+FROM quay.io/fedora/fedora:38 AS build
 
 RUN mkdir -p /mnt/rootfs
 RUN MICRO_PKGS="coreutils-single glibc-minimal-langpack" && \
     INSTALL_PKGS="$MICRO_PKGS httpd-core mod_ssl findutils hostname nss_wrapper-libs fedora-logos-httpd" && \
-    dnf install --installroot /mnt/rootfs --use-host-config $INSTALL_PKGS --releasever 39 --setopt install_weak_deps=false --nodocs -y && \
+    dnf install --installroot /mnt/rootfs $INSTALL_PKGS --releasever 38 --setopt install_weak_deps=false --nodocs -y && \
     dnf -y --installroot /mnt/rootfs clean all && \
     rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.*
 


### PR DESCRIPTION
dnf5 is getting reverted from Fedora 39 soon and the new option is not backwards compatible. Let's revert the commit that introduced the dnf5 fix and move to Fedora 38 base image to not fail the CI.

Fesco ticket: https://pagure.io/fesco/issue/3039

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
