### PR TITLE
imagestreams/httpd-centos: Update for C9S

### DIFF
--- a/imagestreams/httpd-centos.json
+++ b/imagestreams/httpd-centos.json
@@ -1,17 +1,18 @@
 {
-  "apiVersion": "image.openshift.io/v1",
   "kind": "ImageStream",
+  "apiVersion": "image.openshift.io/v1",
   "metadata": {
+    "name": "httpd",
     "annotations": {
       "openshift.io/display-name": "Apache HTTP Server (httpd)"
-    },
-    "name": "httpd"
+    }
   },
   "spec": {
     "tags": [
       {
+        "name": "latest",
         "annotations": {
-          "description": "Build and serve static content via Apache HTTP Server (httpd) on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/httpd-container/blob/master/2.4/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Httpd available on OpenShift, including major version updates.",
+          "description": "Build and serve static content via Apache HTTP Server (httpd) on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/httpd-container/blob/master/2.4/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Httpd available on OpenShift, including major version updates.",
           "iconClass": "icon-apache",
           "openshift.io/display-name": "Apache HTTP Server (Latest)",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
@@ -21,14 +22,54 @@
         },
         "from": {
           "kind": "ImageStreamTag",
-          "name": "2.4-ubi8"
+          "name": "2.4-ubi9"
         },
         "referencePolicy": {
           "type": "Local"
-        },
-        "name": "latest"
+        }
       },
       {
+        "name": "2.4-fc",
+        "annotations": {
+          "description": "Build and serve static content via Apache HTTP Server (httpd) 2.4 on Fedora. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/httpd-container/blob/master/2.4/README.md.",
+          "iconClass": "icon-apache",
+          "openshift.io/display-name": "Apache HTTP Server 2.4 (Fedora)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "sampleRepo": "https://github.com/sclorg/httpd-ex.git",
+          "supports": "httpd",
+          "tags": "builder,httpd",
+          "version": "2.4"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/fedora/httpd-24:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "2.4-micro-fc",
+        "annotations": {
+          "description": "Build and serve static content via Apache HTTP Server (httpd) 2.4 on Fedora. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/httpd-container/blob/master/2.4/README.md.",
+          "iconClass": "icon-apache",
+          "openshift.io/display-name": "Apache HTTP Server 2.4 Micro (Fedora)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "sampleRepo": "https://github.com/sclorg/httpd-ex.git",
+          "supports": "httpd",
+          "tags": "builder,httpd",
+          "version": "2.4"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/fedora/httpd-24-micro:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "2.4-ubi9",
         "annotations": {
           "description": "Build and serve static content via Apache HTTP Server (httpd) 2.4 on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/httpd-container/blob/master/2.4/README.md.",
           "iconClass": "icon-apache",
@@ -45,12 +86,32 @@
         },
         "referencePolicy": {
           "type": "Local"
-        },
-        "name": "2.4-ubi9"
+        }
       },
       {
+        "name": "2.4-micro-c9s",
         "annotations": {
-          "description": "Build and serve static content via Apache HTTP Server (httpd) 2.4 on RHEL 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/httpd-container/blob/master/2.4/README.md.",
+          "description": "Build and serve static content via Apache HTTP Server (httpd) 2.4 on CentOS 9 Stream. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/httpd-container/blob/master/2.4/README.md.",
+          "iconClass": "icon-apache",
+          "openshift.io/display-name": "Apache HTTP Server 2.4 Micro (CentOS 9 Stream)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "sampleRepo": "https://github.com/sclorg/httpd-ex.git",
+          "supports": "httpd",
+          "tags": "builder,httpd",
+          "version": "2.4"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/sclorg/httpd-24-micro-c9s:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "2.4-ubi8",
+        "annotations": {
+          "description": "Build and serve static content via Apache HTTP Server (httpd) 2.4 on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/httpd-container/blob/master/2.4/README.md.",
           "iconClass": "icon-apache",
           "openshift.io/display-name": "Apache HTTP Server 2.4 (UBI 8)",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
@@ -65,30 +126,30 @@
         },
         "referencePolicy": {
           "type": "Local"
-        },
-        "name": "2.4-ubi8"
+        }
       },
       {
+        "name": "2.4-micro-c8s",
         "annotations": {
-          "description": "Build and serve static content via Apache HTTP Server (httpd) 2.4 on CentOS 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/httpd-container/blob/master/2.4/README.md.",
+          "description": "Build and serve static content via Apache HTTP Server (httpd) 2.4 on CentOS 8 Stream. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/httpd-container/blob/master/2.4/README.md.",
           "iconClass": "icon-apache",
-          "openshift.io/display-name": "Apache HTTP Server 2.4 (CentOS 8)",
+          "openshift.io/display-name": "Apache HTTP Server 2.4 Micro (CentOS 8 Stream)",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
           "sampleRepo": "https://github.com/sclorg/httpd-ex.git",
           "supports": "httpd",
-          "tags": "builder,httpd,hidden",
+          "tags": "builder,httpd",
           "version": "2.4"
         },
         "from": {
           "kind": "DockerImage",
-          "name": "docker.io/centos/httpd-24-centos8:latest"
+          "name": "quay.io/sclorg/httpd-24-micro-c8s:latest"
         },
         "referencePolicy": {
           "type": "Local"
-        },
-        "name": "2.4-el8"
+        }
       },
       {
+        "name": "2.4-el7",
         "annotations": {
           "description": "Build and serve static content via Apache HTTP Server (httpd) 2.4 on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/httpd-container/blob/master/2.4/README.md.",
           "iconClass": "icon-apache",
@@ -105,12 +166,12 @@
         },
         "referencePolicy": {
           "type": "Local"
-        },
-        "name": "2.4-el7"
+        }
       },
       {
+        "name": "2.4",
         "annotations": {
-          "description": "Build and serve static content via Apache HTTP Server (httpd) 2.4 on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/httpd-container/blob/master/2.4/README.md.",
+          "description": "Build and serve static content via Apache HTTP Server (httpd) 2.4 on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/httpd-container/blob/master/2.4/README.md.",
           "iconClass": "icon-apache",
           "openshift.io/display-name": "Apache HTTP Server 2.4",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
@@ -121,12 +182,11 @@
         },
         "from": {
           "kind": "DockerImage",
-          "name": "quay.io/centos7/httpd-24-centos7:latest"
+          "name": "registry.access.redhat.com/ubi9/httpd-24:latest"
         },
         "referencePolicy": {
           "type": "Local"
-        },
-        "name": "2.4"
+        }
       }
     ]
   }


### PR DESCRIPTION
Also switch to using the C8S image from quay.io for EL8 instead of pulling from docker.io, avoiding rate-limits.
