### PR TITLE
Add a test in Dockerfile directly to check httpd version

### DIFF
--- a/2.4-micro/Dockerfile.c8s
+++ b/2.4-micro/Dockerfile.c8s
@@ -69,6 +69,7 @@ WORKDIR ${HOME}
 RUN useradd -u 1001 -r -g 0 -d ${HOME} -s /sbin/nologin \
       -c "Default Application User" default && \
   chown -R 1001:0 ${APP_ROOT} && \
+  httpd -v | grep -qe "Apache/$HTTPD_VERSION" && echo "Found VERSION $HTTPD_VERSION" && \
   /usr/libexec/httpd-prepare
 
 USER 1001

--- a/2.4-micro/Dockerfile.c9s
+++ b/2.4-micro/Dockerfile.c9s
@@ -68,6 +68,7 @@ WORKDIR ${HOME}
 RUN useradd -u 1001 -r -g 0 -d ${HOME} -s /sbin/nologin \
       -c "Default Application User" default && \
   chown -R 1001:0 ${APP_ROOT} && \
+  httpd -v | grep -qe "Apache/$HTTPD_VERSION" && echo "Found VERSION $HTTPD_VERSION" && \
   /usr/libexec/httpd-prepare
 
 USER 1001

--- a/2.4-micro/Dockerfile.fedora
+++ b/2.4-micro/Dockerfile.fedora
@@ -68,6 +68,7 @@ WORKDIR ${HOME}
 RUN useradd -u 1001 -r -g 0 -d ${HOME} -s /sbin/nologin \
       -c "Default Application User" default && \
   chown -R 1001:0 ${APP_ROOT} && \
+  httpd -v | grep -qe "Apache/$HTTPD_VERSION" && echo "Found VERSION $HTTPD_VERSION" && \
   /usr/libexec/httpd-prepare
 
 USER 1001

--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -37,6 +37,7 @@ RUN yum install -y yum-utils && \
     INSTALL_PKGS="gettext hostname nss_wrapper bind-utils httpd24 httpd24-mod_ssl httpd24-mod_ldap httpd24-mod_session httpd24-mod_auth_mellon httpd24-mod_security openssl" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+    scl enable httpd24 -- httpd -v | grep -qe "Apache/$HTTPD_VERSION" && echo "Found VERSION $HTTPD_VERSION" && \
     yum -y clean all --enablerepo='*'
 
 ENV HTTPD_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/httpd/ \

--- a/2.4/Dockerfile.fedora
+++ b/2.4/Dockerfile.fedora
@@ -38,6 +38,7 @@ RUN dnf install -y yum-utils gettext hostname && \
     INSTALL_PKGS="nss_wrapper bind-utils httpd mod_ssl mod_ldap mod_session mod_security sscg" && \
     dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+    httpd -v | grep -qe "Apache/$HTTPD_VERSION" && echo "Found VERSION $HTTPD_VERSION" && \
     dnf clean all
 
 ENV HTTPD_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/httpd/ \

--- a/2.4/Dockerfile.rhel7
+++ b/2.4/Dockerfile.rhel7
@@ -38,6 +38,7 @@ RUN yum install -y yum-utils && \
     INSTALL_PKGS="gettext hostname nss_wrapper bind-utils httpd24 httpd24-mod_ssl httpd24-mod_ldap httpd24-mod_session httpd24-mod_auth_mellon httpd24-mod_security openssl" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+    scl enable httpd24 -- httpd -v | grep -qe "Apache/$HTTPD_VERSION" && echo "Found VERSION $HTTPD_VERSION" && \
     yum -y clean all --enablerepo='*'
 
 ENV HTTPD_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/httpd/ \

--- a/2.4/Dockerfile.rhel8
+++ b/2.4/Dockerfile.rhel8
@@ -37,6 +37,7 @@ RUN yum -y module enable httpd:$HTTPD_VERSION && \
     INSTALL_PKGS="gettext hostname nss_wrapper bind-utils httpd mod_ssl mod_ldap mod_session mod_security mod_auth_mellon sscg" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+    httpd -v | grep -qe "Apache/$HTTPD_VERSION" && echo "Found VERSION $HTTPD_VERSION" && \
     yum -y clean all --enablerepo='*'
 
 ENV HTTPD_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/httpd/ \

--- a/2.4/Dockerfile.rhel9
+++ b/2.4/Dockerfile.rhel9
@@ -36,6 +36,7 @@ EXPOSE 8443
 RUN INSTALL_PKGS="gettext hostname nss_wrapper bind-utils httpd mod_ssl mod_ldap mod_session mod_security mod_auth_mellon sscg" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+    httpd -v | grep -qe "Apache/$HTTPD_VERSION" && echo "Found VERSION $HTTPD_VERSION" && \
     yum -y clean all --enablerepo='*'
 
 ENV HTTPD_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/httpd/ \


### PR DESCRIPTION
Add a test in Dockerfile directly to check httpd version

Otherwise when a wrong stream is installed, it's only found by scl test, which is too late in the process.

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
