### PR TITLE
use /bin/bash instead of /sbin/nologin as default shell for default user as s2i-core did

### DIFF
--- a/2.4-micro/Dockerfile.c8s
+++ b/2.4-micro/Dockerfile.c8s
@@ -66,8 +66,7 @@ COPY 2.4-micro/core-scripts/usr /usr
 WORKDIR ${HOME}
 
 # Add default user and prepare httpd
-RUN useradd -u 1001 -r -g 0 -d ${HOME} -s /sbin/nologin \
-      -c "Default Application User" default && \
+RUN useradd -u 1001 -r -g 0 -d ${HOME} -c "Default Application User" default && \
   chown -R 1001:0 ${APP_ROOT} && \
   httpd -v | grep -qe "Apache/$HTTPD_VERSION" && echo "Found VERSION $HTTPD_VERSION" && \
   /usr/libexec/httpd-prepare

--- a/2.4-micro/Dockerfile.c9s
+++ b/2.4-micro/Dockerfile.c9s
@@ -65,8 +65,7 @@ COPY 2.4-micro/core-scripts/usr /usr
 WORKDIR ${HOME}
 
 # Add default user and prepare httpd
-RUN useradd -u 1001 -r -g 0 -d ${HOME} -s /sbin/nologin \
-      -c "Default Application User" default && \
+RUN useradd -u 1001 -r -g 0 -d ${HOME} -c "Default Application User" default && \
   chown -R 1001:0 ${APP_ROOT} && \
   httpd -v | grep -qe "Apache/$HTTPD_VERSION" && echo "Found VERSION $HTTPD_VERSION" && \
   /usr/libexec/httpd-prepare

--- a/2.4-micro/Dockerfile.fedora
+++ b/2.4-micro/Dockerfile.fedora
@@ -65,8 +65,7 @@ COPY 2.4-micro/core-scripts/usr /usr
 WORKDIR ${HOME}
 
 # Add default user and prepare httpd
-RUN useradd -u 1001 -r -g 0 -d ${HOME} -s /sbin/nologin \
-      -c "Default Application User" default && \
+RUN useradd -u 1001 -r -g 0 -d ${HOME} -c "Default Application User" default && \
   chown -R 1001:0 ${APP_ROOT} && \
   httpd -v | grep -qe "Apache/$HTTPD_VERSION" && echo "Found VERSION $HTTPD_VERSION" && \
   /usr/libexec/httpd-prepare

--- a/2.4-micro/root/usr/share/container-scripts/httpd/common.sh
+++ b/2.4-micro/root/usr/share/container-scripts/httpd/common.sh
@@ -156,7 +156,7 @@ generate_container_user() {
   export USER_ID=$(id -u)
   export GROUP_ID=$(id -g)
   cp ${HTTPD_CONTAINER_SCRIPTS_PATH}/passwd.template ${passwd_output_dir}/passwd
-  echo "default:x:${USER_ID}:${GROUP_ID}:Default Application User:${HOME}:/sbin/nologin" >> ${passwd_output_dir}/passwd
+  echo "default:x:${USER_ID}:${GROUP_ID}:Default Application User:${HOME}:/bin/bash" >> ${passwd_output_dir}/passwd
   export LD_PRELOAD=libnss_wrapper.so
   export NSS_WRAPPER_PASSWD=${passwd_output_dir}/passwd
   export NSS_WRAPPER_GROUP=/etc/group

--- a/2.4/root/usr/share/container-scripts/httpd/common.sh
+++ b/2.4/root/usr/share/container-scripts/httpd/common.sh
@@ -160,7 +160,7 @@ generate_container_user() {
   export USER_ID=$(id -u)
   export GROUP_ID=$(id -g)
   cp ${HTTPD_CONTAINER_SCRIPTS_PATH}/passwd.template ${passwd_output_dir}/passwd
-  echo "default:x:${USER_ID}:${GROUP_ID}:Default Application User:${HOME}:/sbin/nologin" >> ${passwd_output_dir}/passwd
+  echo "default:x:${USER_ID}:${GROUP_ID}:Default Application User:${HOME}:/bin/bash" >> ${passwd_output_dir}/passwd
   export LD_PRELOAD=libnss_wrapper.so
   export NSS_WRAPPER_PASSWD=${passwd_output_dir}/passwd
   export NSS_WRAPPER_GROUP=/etc/group


### PR DESCRIPTION
Partially fixes: https://github.com/sclorg/s2i-base-container/issues/283
Related: https://github.com/sclorg/s2i-base-container/pull/284
