### PR TITLE
Support latest imagestreams and httpd ex repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Variables are documented in common/build.sh.
 BASE_IMAGE_NAME = httpd
-VERSIONS = 2.4 2.4-micro
+VERSIONS = 2.4-micro 2.4
 OPENSHIFT_NAMESPACES = 
 DOCKER_BUILD_CONTEXT = ..
 

--- a/test/run-openshift-local-cluster
+++ b/test/run-openshift-local-cluster
@@ -19,13 +19,6 @@ set -eo nounset
 
 trap ct_os_cleanup EXIT SIGINT
 
-function test_latest_imagestreams() {
-  # Switch to root directory of a container
-  pushd ${test_dir}/../.. >/dev/null
-  ct_check_latest_imagestreams
-  popd >/dev/null
-}
-
 ct_os_check_compulsory_vars
 
 ct_os_enable_print_logs

--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -16,6 +16,8 @@ source ${THISDIR}/test-lib-remote-openshift.sh
 TEST_LIST="\
 test_httpd_integration
 test_httpd_imagestream
+test_httpd_example_repo
+test_latest_imagestreams
 "
 
 trap ct_os_cleanup EXIT SIGINT

--- a/test/test-lib-httpd.sh
+++ b/test/test-lib-httpd.sh
@@ -31,4 +31,19 @@ function test_httpd_imagestream() {
                               "This is a sample s2i application with static content"
 }
 
+function test_httpd_example_repo {
+  BRANCH_TO_TEST=master
+  # test remote example app
+  ct_os_test_s2i_app "${IMAGE_NAME}" "https://github.com/sclorg/httpd-ex#${BRANCH_TO_TEST}" \
+                      "." \
+                      'Welcome to your static httpd application on OpenShift'
+}
+
+function test_latest_imagestreams() {
+  # Switch to root directory of a container
+  pushd ${THISDIR}/../.. >/dev/null
+  ct_check_latest_imagestreams
+  popd >/dev/null
+}
+
 # vim: set tabstop=2:shiftwidth=2:expandtab:


### PR DESCRIPTION
Support latest imagestreams and httpd ex repo

Move test_latest_imagestreams from run-openshift-local-cluster to test-lib-httpd.sh
So it can be used in run-openshift-remote-cluster as well and code is not duplicated.
Added also test suite for testing httpd-ex repository.

Change in VERSIONS file:
Micro image is not presented in imagestreams files and we need to check proper version like '2.4' in this case.

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
