### PR TITLE
Support c10s in httpd-container

### DIFF
--- a/2.4-micro/Dockerfile.c10s
+++ b/2.4-micro/Dockerfile.c10s
@@ -1,0 +1,80 @@
+FROM quay.io/centos/centos:stream9 AS build
+
+RUN mkdir -p /mnt/rootfs
+RUN MICRO_PKGS="coreutils-single glibc-minimal-langpack" && \
+    INSTALL_PKGS="$MICRO_PKGS httpd-core mod_ssl findutils hostname nss_wrapper-libs redhat-logos-httpd" && \
+    dnf install --installroot /mnt/rootfs $INSTALL_PKGS --releasever 9 --setopt install_weak_deps=false --nodocs -y && \
+    dnf -y --installroot /mnt/rootfs clean all && \
+    rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.*
+
+FROM scratch
+# Apache HTTP Server image.
+#
+# Volumes:
+#  * /var/www - Datastore for httpd
+#  * /var/log/httpd24 - Storage for logs when $HTTPD_LOG_TO_VOLUME is set
+# Environment:
+#  * $HTTPD_LOG_TO_VOLUME (optional) - When set, httpd will log into /var/log/httpd24
+
+ENV HTTPD_VERSION=2.4
+
+ENV SUMMARY="Platform for running Apache httpd $HTTPD_VERSION or building httpd-based application" \
+    DESCRIPTION="Apache httpd $HTTPD_VERSION available as container, is a powerful, efficient, \
+and extensible web server. Apache supports a variety of features, many implemented as compiled modules \
+which extend the core functionality. \
+These can range from server-side programming language support to authentication schemes. \
+Virtual hosting allows one Apache installation to serve many different Web sites." \
+# The following variables are usually available from parent s2i images \
+    STI_SCRIPTS_PATH=/usr/libexec/s2i \
+    APP_ROOT=/opt/app-root \
+    HOME=/opt/app-root/src \
+    PLATFORM="el9"
+
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="Apache httpd $HTTPD_VERSION" \
+      io.openshift.expose-services="8080:http,8443:https" \
+      io.openshift.tags="builder,httpd,httpd-24" \
+      name="sclorg/httpd-24-micro-c9s" \
+      version="1" \
+      usage="s2i build https://github.com/sclorg/httpd-container.git --context-dir=examples/sample-test-app/ sclorg/httpd-24-micro-c9s sample-server" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
+
+EXPOSE 8080
+EXPOSE 8443
+
+COPY --from=build /mnt/rootfs/ /
+
+ENV HTTPD_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/httpd/ \
+    HTTPD_APP_ROOT=${APP_ROOT} \
+    HTTPD_CONFIGURATION_PATH=${APP_ROOT}/etc/httpd.d \
+    HTTPD_MAIN_CONF_PATH=/etc/httpd/conf \
+    HTTPD_MAIN_CONF_MODULES_D_PATH=/etc/httpd/conf.modules.d \
+    HTTPD_MAIN_CONF_D_PATH=/etc/httpd/conf.d \
+    HTTPD_TLS_CERT_PATH=/etc/httpd/tls \
+    HTTPD_VAR_RUN=/var/run/httpd \
+    HTTPD_DATA_PATH=/var/www \
+    HTTPD_DATA_ORIG_PATH=/var/www \
+    HTTPD_LOG_PATH=/var/log/httpd
+
+COPY 2.4-micro/s2i/bin/ $STI_SCRIPTS_PATH
+COPY 2.4-micro/root /
+COPY 2.4-micro/core-scripts/usr /usr
+
+WORKDIR ${HOME}
+
+# Add default user and prepare httpd
+RUN useradd -u 1001 -r -g 0 -d ${HOME} -c "Default Application User" default && \
+  chown -R 1001:0 ${APP_ROOT} && \
+  httpd -v | grep -qe "Apache/$HTTPD_VERSION" && echo "Found VERSION $HTTPD_VERSION" && \
+  /usr/libexec/httpd-prepare
+
+USER 1001
+
+# Not using VOLUME statement since it's not working in OpenShift Online:
+# https://github.com/sclorg/httpd-container/issues/30
+# VOLUME ["${HTTPD_DATA_PATH}"]
+# VOLUME ["${HTTPD_LOG_PATH}"]
+
+CMD ["/usr/bin/run-httpd"]

--- a/2.4-micro/Dockerfile.c10s
+++ b/2.4-micro/Dockerfile.c10s
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:stream9 AS build
+FROM quay.io/centos/centos:stream10-development AS build
 
 RUN mkdir -p /mnt/rootfs
 RUN MICRO_PKGS="coreutils-single glibc-minimal-langpack" && \
@@ -16,7 +16,9 @@ FROM scratch
 # Environment:
 #  * $HTTPD_LOG_TO_VOLUME (optional) - When set, httpd will log into /var/log/httpd24
 
-ENV HTTPD_VERSION=2.4
+ENV HTTPD_VERSION=2.4 \
+    HTTPD_SHORT_VERSION=24 \
+    NAME=httpd
 
 ENV SUMMARY="Platform for running Apache httpd $HTTPD_VERSION or building httpd-based application" \
     DESCRIPTION="Apache httpd $HTTPD_VERSION available as container, is a powerful, efficient, \
@@ -28,17 +30,17 @@ Virtual hosting allows one Apache installation to serve many different Web sites
     STI_SCRIPTS_PATH=/usr/libexec/s2i \
     APP_ROOT=/opt/app-root \
     HOME=/opt/app-root/src \
-    PLATFORM="el9"
+    PLATFORM="el10"
 
 LABEL summary="$SUMMARY" \
       description="$DESCRIPTION" \
       io.k8s.description="$DESCRIPTION" \
       io.k8s.display-name="Apache httpd $HTTPD_VERSION" \
       io.openshift.expose-services="8080:http,8443:https" \
-      io.openshift.tags="builder,httpd,httpd-24" \
-      name="sclorg/httpd-24-micro-c9s" \
+      io.openshift.tags="builder,httpd,httpd-$HTTPD_SHORT_VERSION" \
+      name="sclorg/$NAME-$HTTPD_SHORT_VERSION-micro-c10s" \
       version="1" \
-      usage="s2i build https://github.com/sclorg/httpd-container.git --context-dir=examples/sample-test-app/ sclorg/httpd-24-micro-c9s sample-server" \
+      usage="s2i build https://github.com/sclorg/httpd-container.git --context-dir=examples/sample-test-app/ sclorg/$NAME-$HTTPD_SHORT_VERSION-micro-c10s sample-server" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 EXPOSE 8080

--- a/2.4-micro/root/usr/share/container-scripts/httpd/README.md
+++ b/2.4-micro/root/usr/share/container-scripts/httpd/README.md
@@ -246,4 +246,5 @@ See also
 Dockerfile and other sources for this container image are available on
 https://github.com/sclorg/httpd-container.
 In that repository, the Dockerfile for RHEL8 is called Dockerfile.rhel8,
+the Dockerfile for CentOS Stream 10 is called Dockerfile.c10s,
 and the Dockerfile for Fedora is called Dockerfile.fedora.

--- a/2.4/Dockerfile.c10s
+++ b/2.4/Dockerfile.c10s
@@ -10,7 +10,8 @@ FROM quay.io/sclorg/s2i-core-c10s:c10s
 
 ENV HTTPD_VERSION=2.4 \
     HTTPD_SHORT_VERSION=24 \
-    NAME=httpd
+    NAME=httpd \
+    ARCH=x86_64
 
 ENV SUMMARY="Platform for running Apache httpd $HTTPD_VERSION or building httpd-based application" \
     DESCRIPTION="Apache httpd $HTTPD_VERSION available as container, is a powerful, efficient, \
@@ -36,10 +37,10 @@ EXPOSE 8080
 EXPOSE 8443
 
 RUN INSTALL_PKGS="gettext hostname nss_wrapper bind-utils httpd mod_ssl mod_ldap mod_session sscg" && \
-    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     httpd -v | grep -qe "Apache/$HTTPD_VERSION" && echo "Found VERSION $HTTPD_VERSION" && \
-    yum -y clean all --enablerepo='*'
+    dnf -y clean all --enablerepo='*'
 
 ENV HTTPD_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/httpd/ \
     HTTPD_APP_ROOT=${APP_ROOT} \

--- a/2.4/Dockerfile.c10s
+++ b/2.4/Dockerfile.c10s
@@ -1,4 +1,4 @@
-FROM quay.io/sclorg/s2i-core-c9s:c9s
+FROM quay.io/sclorg/s2i-core-c10s:c10s
 
 # Apache HTTP Server image.
 #
@@ -8,7 +8,9 @@ FROM quay.io/sclorg/s2i-core-c9s:c9s
 # Environment:
 #  * $HTTPD_LOG_TO_VOLUME (optional) - When set, httpd will log into /var/log/httpd24
 
-ENV HTTPD_VERSION=2.4
+ENV HTTPD_VERSION=2.4 \
+    HTTPD_SHORT_VERSION=24 \
+    NAME=httpd
 
 ENV SUMMARY="Platform for running Apache httpd $HTTPD_VERSION or building httpd-based application" \
     DESCRIPTION="Apache httpd $HTTPD_VERSION available as container, is a powerful, efficient, \
@@ -22,18 +24,18 @@ LABEL summary="$SUMMARY" \
       io.k8s.description="$DESCRIPTION" \
       io.k8s.display-name="Apache httpd $HTTPD_VERSION" \
       io.openshift.expose-services="8080:http,8443:https" \
-      io.openshift.tags="builder,httpd,httpd-24" \
-      name="sclorg/httpd-24-c9s" \
+      io.openshift.tags="builder,$NAME,$NAME-$HTTPD_SHORT_VERSION" \
+      name="sclorg/$NAME-$HTTPD_SHORT_VERSION-c10s" \
       version="1" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
       com.redhat.component="httpd-24-container" \
-      usage="s2i build https://github.com/sclorg/httpd-container.git --context-dir=examples/sample-test-app/ quay.io/sclorg/httpd-24-c9s sample-server" \
+      usage="s2i build https://github.com/sclorg/httpd-container.git --context-dir=examples/sample-test-app/ quay.io/sclorg/$NAME-$HTTPD_SHORT_VERSION-c10s sample-server" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 EXPOSE 8080
 EXPOSE 8443
 
-RUN INSTALL_PKGS="gettext hostname nss_wrapper bind-utils httpd mod_ssl mod_ldap mod_session mod_security mod_auth_mellon sscg" && \
+RUN INSTALL_PKGS="gettext hostname nss_wrapper bind-utils httpd mod_ssl mod_ldap mod_session sscg" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     httpd -v | grep -qe "Apache/$HTTPD_VERSION" && echo "Found VERSION $HTTPD_VERSION" && \

--- a/2.4/Dockerfile.c10s
+++ b/2.4/Dockerfile.c10s
@@ -1,0 +1,67 @@
+FROM quay.io/sclorg/s2i-core-c9s:c9s
+
+# Apache HTTP Server image.
+#
+# Volumes:
+#  * /var/www - Datastore for httpd
+#  * /var/log/httpd24 - Storage for logs when $HTTPD_LOG_TO_VOLUME is set
+# Environment:
+#  * $HTTPD_LOG_TO_VOLUME (optional) - When set, httpd will log into /var/log/httpd24
+
+ENV HTTPD_VERSION=2.4
+
+ENV SUMMARY="Platform for running Apache httpd $HTTPD_VERSION or building httpd-based application" \
+    DESCRIPTION="Apache httpd $HTTPD_VERSION available as container, is a powerful, efficient, \
+and extensible web server. Apache supports a variety of features, many implemented as compiled modules \
+which extend the core functionality. \
+These can range from server-side programming language support to authentication schemes. \
+Virtual hosting allows one Apache installation to serve many different Web sites."
+
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="Apache httpd $HTTPD_VERSION" \
+      io.openshift.expose-services="8080:http,8443:https" \
+      io.openshift.tags="builder,httpd,httpd-24" \
+      name="sclorg/httpd-24-c9s" \
+      version="1" \
+      com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#rhel" \
+      com.redhat.component="httpd-24-container" \
+      usage="s2i build https://github.com/sclorg/httpd-container.git --context-dir=examples/sample-test-app/ quay.io/sclorg/httpd-24-c9s sample-server" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
+
+EXPOSE 8080
+EXPOSE 8443
+
+RUN INSTALL_PKGS="gettext hostname nss_wrapper bind-utils httpd mod_ssl mod_ldap mod_session mod_security mod_auth_mellon sscg" && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    httpd -v | grep -qe "Apache/$HTTPD_VERSION" && echo "Found VERSION $HTTPD_VERSION" && \
+    yum -y clean all --enablerepo='*'
+
+ENV HTTPD_CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/httpd/ \
+    HTTPD_APP_ROOT=${APP_ROOT} \
+    HTTPD_CONFIGURATION_PATH=${APP_ROOT}/etc/httpd.d \
+    HTTPD_MAIN_CONF_PATH=/etc/httpd/conf \
+    HTTPD_MAIN_CONF_MODULES_D_PATH=/etc/httpd/conf.modules.d \
+    HTTPD_MAIN_CONF_D_PATH=/etc/httpd/conf.d \
+    HTTPD_TLS_CERT_PATH=/etc/httpd/tls \
+    HTTPD_VAR_RUN=/var/run/httpd \
+    HTTPD_DATA_PATH=/var/www \
+    HTTPD_DATA_ORIG_PATH=/var/www \
+    HTTPD_LOG_PATH=/var/log/httpd
+
+COPY 2.4/s2i/bin/ $STI_SCRIPTS_PATH
+COPY 2.4/root /
+
+# Reset permissions of filesystem to default values
+RUN /usr/libexec/httpd-prepare && rpm-file-permissions
+
+USER 1001
+
+# Not using VOLUME statement since it's not working in OpenShift Online:
+# https://github.com/sclorg/httpd-container/issues/30
+# VOLUME ["${HTTPD_DATA_PATH}"]
+# VOLUME ["${HTTPD_LOG_PATH}"]
+
+CMD ["/usr/bin/run-httpd"]

--- a/2.4/Dockerfile.fedora
+++ b/2.4/Dockerfile.fedora
@@ -1,4 +1,4 @@
-FROM quay.io/fedora/s2i-core:38
+FROM quay.io/fedora/s2i-core:40
 
 # Apache HTTP Server image.
 #
@@ -9,6 +9,7 @@ FROM quay.io/fedora/s2i-core:38
 #  * $HTTPD_LOG_TO_VOLUME (optional) - When set, httpd will log into /var/log/httpd
 
 ENV HTTPD_VERSION=2.4 \
+    HTTPD_SHORT_VERSION=24 \
     NAME=httpd \
     ARCH=x86_64
 
@@ -24,11 +25,11 @@ LABEL summary="$SUMMARY" \
       io.k8s.description="$SUMMARY" \
       io.k8s.display-name="Apache httpd $HTTPD_VERSION" \
       io.openshift.expose-services="8080:http,8443:https" \
-      io.openshift.tags="builder,httpd,httpd24" \
+      io.openshift.tags="builder,$NAME,$NAME24" \
       com.redhat.component="$NAME" \
-      name="fedora/$NAME-24" \
+      name="fedora/$NAME-$HTTPD_SHORT_VERSION" \
       version="$HTTPD_VERSION" \
-      usage="s2i build https://github.com/sclorg/httpd-container.git --context-dir=examples/sample-test-app/ quya.io/fedora/$NAME-24 sample-server" \
+      usage="s2i build https://github.com/sclorg/httpd-container.git --context-dir=examples/sample-test-app/ quya.io/fedora/$NAME-$HTTPD_SHORT_VERSION sample-server" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 EXPOSE 8080

--- a/2.4/Dockerfile.rhel9
+++ b/2.4/Dockerfile.rhel9
@@ -8,7 +8,9 @@ FROM ubi9/s2i-core:1
 # Environment:
 #  * $HTTPD_LOG_TO_VOLUME (optional) - When set, httpd will log into /var/log/httpd24
 
-ENV HTTPD_VERSION=2.4
+ENV HTTPD_VERSION=2.4 \
+    HTTPD_SHORT_VERSION=24 \
+    NAME
 
 ENV SUMMARY="Platform for running Apache httpd $HTTPD_VERSION or building httpd-based application" \
     DESCRIPTION="Apache httpd $HTTPD_VERSION available as container, is a powerful, efficient, \
@@ -22,12 +24,12 @@ LABEL summary="$SUMMARY" \
       io.k8s.description="$DESCRIPTION" \
       io.k8s.display-name="Apache httpd $HTTPD_VERSION" \
       io.openshift.expose-services="8080:http,8443:https" \
-      io.openshift.tags="builder,httpd,httpd-24" \
-      name="rhel9/httpd-24" \
+      io.openshift.tags="builder,$NAME,$NAME-$HTTPD_SHORT_VERSION" \
+      name="rhel9/$NAME-$HTTPD_SHORT_VERSION" \
       version="1" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI" \
-      com.redhat.component="httpd-24-container" \
-      usage="s2i build https://github.com/sclorg/httpd-container.git --context-dir=examples/sample-test-app/ rhel9/httpd-24 sample-server" \
+      com.redhat.component="$NAME-$HTTPD_SHORT_VERSION-container" \
+      usage="s2i build https://github.com/sclorg/httpd-container.git --context-dir=examples/sample-test-app/ rhel9/$NAME-$HTTPD_SHORT_VERSION sample-server" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 EXPOSE 8080

--- a/2.4/Dockerfile.rhel9
+++ b/2.4/Dockerfile.rhel9
@@ -10,7 +10,7 @@ FROM ubi9/s2i-core:1
 
 ENV HTTPD_VERSION=2.4 \
     HTTPD_SHORT_VERSION=24 \
-    NAME
+    NAME=httpd
 
 ENV SUMMARY="Platform for running Apache httpd $HTTPD_VERSION or building httpd-based application" \
     DESCRIPTION="Apache httpd $HTTPD_VERSION available as container, is a powerful, efficient, \

--- a/2.4/root/usr/share/container-scripts/httpd/README.md
+++ b/2.4/root/usr/share/container-scripts/httpd/README.md
@@ -246,4 +246,5 @@ https://github.com/sclorg/httpd-container.
 In that repository, the Dockerfile for RHEL8 is called Dockerfile.rhel8,
 the Dockerfile for RHEL9 is called Dockerfile.rhel9,
 the Dockerfile for CentOS Stream 9 is called Dockerfile.c9s,
+the Dockerfile for CentOS Stream 10 is called Dockerfile.c10s,
 and the Dockerfile for Fedora is called Dockerfile.fedora.

--- a/2.4/root/usr/share/container-scripts/httpd/common.sh
+++ b/2.4/root/usr/share/container-scripts/httpd/common.sh
@@ -2,11 +2,13 @@
 
 if head "/etc/redhat-release" | grep -q "^Red Hat Enterprise Linux release 8"; then
   HTTPCONF_LINENO=154
-elif head "/etc/redhat-release" | grep -q "^CentOS Stream release 8"; then
-  HTTPCONF_LINENO=154
+elif head "/etc/redhat-release" | grep -q "^CentOS Stream release 10"; then
+  HTTPCONF_LINENO=156
 elif head "/etc/redhat-release" | grep -q "^Fedora"; then
   HTTPCONF_LINENO=156
 elif [ "x$PLATFORM" == "xel9" ];  then
+  HTTPCONF_LINENO=156
+elif [ "x$PLATFORM" == "xel10" ];  then
   HTTPCONF_LINENO=156
 else
   HTTPCONF_LINENO=151

--- a/README.md
+++ b/README.md
@@ -27,11 +27,12 @@ RHEL versions currently supported are:
 
 CentOS Stream versions currently supported are:
 * CentOS Stream 9
+* CentOS Stream 10
 
 
 Installation
 ------------
-Choose either the CentOS Stream 9 or RHEL8 based image:
+Choose either the CentOS Stream 9, CentOS Stream 10 or RHEL8 based image:
 
 *  **RHEL8 based image**
 
@@ -92,7 +93,7 @@ Test
 This repository also provides a test framework, which checks basic functionality
 of the Apache HTTP Server image.
 
-Users can choose between testing Apache HTTP Server based on a RHEL or CentOS image.
+Users can choose between testing Apache HTTP Server based on a RHEL or CentOS Stream image.
 
 *  **RHEL based image**
 
@@ -105,7 +106,7 @@ Users can choose between testing Apache HTTP Server based on a RHEL or CentOS im
     $ make test TARGET=rhel8 VERSIONS=2.4
     ```
 
-*  **CentOS based image**
+*  **CentOS Stream based image**
 
     ```
     $ cd httpd-container

--- a/test/run
+++ b/test/run
@@ -28,7 +28,7 @@ function run_default_page_test() {
   # Check default page
   run "ct_create_container test_default_page"
   cip=$(ct_get_cip 'test_default_page')
-  if [[ "${OS}" == "c9s" ]] || [[ "${OS}" == "c8s" ]]; then
+  if [[ "${OS}" == "c9s" ]] || [[ "${OS}" == "c10s" ]]; then
     run "ct_test_response '${cip}':8080 403 'HTTP Server Test Page' 50"
   else
     run "ct_test_response '${cip}':8080 403 'Test Page for the (Apache )?HTTP Server on' 50"
@@ -39,7 +39,7 @@ function run_as_root_test() {
   # Try running as root
   CONTAINER_ARGS="--user 0" run "ct_create_container test_run_as_root"
   cip=$(ct_get_cip 'test_run_as_root')
-  if [[ "${OS}" == "c9s" ]] || [[ "${OS}" == "c8s" ]]; then
+  if [[ "${OS}" == "c9s" ]] || [[ "${OS}" == "c10s" ]]; then
     run "ct_test_response '${cip}':8080 403 'HTTP Server Test Page'"
   else
     run "ct_test_response '${cip}':8080 403 'Test Page for the (Apache )?HTTP Server on'"


### PR DESCRIPTION
This pull request adds support for C10S and it is separated into multiple commits.

- Copy Dockerfile.c9s -> Dockerfile.c10s
- Update Dockerfiles for Fedora, C9S, C10S and RHEL9
- Update test suite
- Update Documentation.
