### PR TITLE
Enable building C10S to quay.io

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -39,6 +39,22 @@ jobs:
             quayio_username: "QUAY_IMAGE_SCLORG_BUILDER_USERNAME"
             quayio_token: "QUAY_IMAGE_SCLORG_BUILDER_TOKEN"
 
+          - dockerfile: "2.4/Dockerfile.c10s"
+            docker_context: "2.4"
+            registry_namespace: "sclorg"
+            tag: "c10s"
+            image_name: "httpd-24-c10s"
+            quayio_username: "QUAY_IMAGE_SCLORG_BUILDER_USERNAME"
+            quayio_token: "QUAY_IMAGE_SCLORG_BUILDER_TOKEN"
+
+          - dockerfile: "2.4-micro/Dockerfile.c10s"
+            docker_context: "2.4-micro"
+            registry_namespace: "sclorg"
+            tag: "c10s"
+            image_name: "httpd-24-micro-c10s"
+            quayio_username: "QUAY_IMAGE_SCLORG_BUILDER_USERNAME"
+            quayio_token: "QUAY_IMAGE_SCLORG_BUILDER_TOKEN"
+
           - dockerfile: "2.4-micro/Dockerfile.fedora"
             docker_context: "2.4-micro"
             registry_namespace: "fedora"


### PR DESCRIPTION
This pull request enables building and pushing httpd C10S image to quay.io

<!-- issue-commentator = {"comment-id":"2374007366"} -->



























































<!-- testing-farm = {"lock":"false","comment-id":"2374214443","data":[{"id":"faabe3ec-8b55-42ef-bf4a-4ac9116d2396","name":"CentOS Stream 9 - 2.4","status":"complete","outcome":"passed","runTime":1320.684698,"created":"2024-09-25T13:51:36.487011","updated":"2024-09-25T13:51:36.487018","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/faabe3ec-8b55-42ef-bf4a-4ac9116d2396\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/faabe3ec-8b55-42ef-bf4a-4ac9116d2396/pipeline.log\">pipeline</a>"]},{"id":"5d350538-9fed-4502-aa5f-d9763383888b","name":"CentOS Stream 10 - 2.4-micro","status":"complete","outcome":"passed","runTime":1359.981255,"created":"2024-09-25T13:51:51.312095","updated":"2024-09-25T13:51:51.312102","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/5d350538-9fed-4502-aa5f-d9763383888b\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/5d350538-9fed-4502-aa5f-d9763383888b/pipeline.log\">pipeline</a>"]},{"id":"ed6db348-d1e4-4560-b776-90480ff94c53","name":"Fedora - 2.4","status":"complete","outcome":"passed","runTime":1417.106439,"created":"2024-09-25T13:51:35.079035","updated":"2024-09-25T13:51:35.079044","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/ed6db348-d1e4-4560-b776-90480ff94c53\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/ed6db348-d1e4-4560-b776-90480ff94c53/pipeline.log\">pipeline</a>"]},{"id":"1d44c838-866b-404b-9e3a-a47fcbd710f8","name":"Fedora - 2.4-micro","status":"complete","outcome":"passed","runTime":1510.340199,"created":"2024-09-25T13:51:32.811738","updated":"2024-09-25T13:51:32.811745","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/1d44c838-866b-404b-9e3a-a47fcbd710f8\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/1d44c838-866b-404b-9e3a-a47fcbd710f8/pipeline.log\">pipeline</a>"]},{"id":"02bd712b-45d4-4cf6-b9b3-41ec432d7bca","name":"CentOS Stream 10 - 2.4","status":"complete","outcome":"passed","runTime":1526.148333,"created":"2024-09-25T13:51:34.187136","updated":"2024-09-25T13:51:34.187143","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/02bd712b-45d4-4cf6-b9b3-41ec432d7bca\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/02bd712b-45d4-4cf6-b9b3-41ec432d7bca/pipeline.log\">pipeline</a>"]},{"id":"fd624ac2-6fc9-4f2a-91f6-a387c24ee60b","name":"CentOS Stream 9 - 2.4-micro","status":"complete","outcome":"passed","runTime":1560.168262,"created":"2024-09-25T13:51:33.104476","updated":"2024-09-25T13:51:33.104484","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/fd624ac2-6fc9-4f2a-91f6-a387c24ee60b\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/fd624ac2-6fc9-4f2a-91f6-a387c24ee60b/pipeline.log\">pipeline</a>"]},{"id":"622f7602-f51b-4cae-a440-3fba581eccaf","name":"RHEL8 - 2.4","runTime":1512.46559,"created":"2024-09-26T07:01:46.366674","updated":"2024-09-26T07:01:46.366680","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/622f7602-f51b-4cae-a440-3fba581eccaf\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/622f7602-f51b-4cae-a440-3fba581eccaf/pipeline.log\">pipeline</a>"]},{"id":"74b46f56-c2a1-4eee-b48b-b137c6da8138","name":"RHEL9 - 2.4","status":"complete","outcome":"passed","runTime":1421.204107,"created":"2024-09-26T07:01:47.969554","updated":"2024-09-26T07:01:47.969559","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/74b46f56-c2a1-4eee-b48b-b137c6da8138\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/74b46f56-c2a1-4eee-b48b-b137c6da8138/pipeline.log\">pipeline</a>"]}]} -->