### PR TITLE
Rename PyTest files so helm tests are executed as the last.

### DIFF
--- a/2.4-micro/test/test_httpd_helm_chart_imagestreams.py
+++ b/2.4-micro/test/test_httpd_helm_chart_imagestreams.py
@@ -1,1 +1,0 @@
-../../test/test_httpd_helm_chart_imagestreams.py

--- a/2.4-micro/test/test_httpd_helm_chart_template.py
+++ b/2.4-micro/test/test_httpd_helm_chart_template.py
@@ -1,1 +1,0 @@
-../../test/test_httpd_helm_chart_template.py

--- a/2.4-micro/test/test_httpd_shared_helm_imagestreams.py
+++ b/2.4-micro/test/test_httpd_shared_helm_imagestreams.py
@@ -1,0 +1,1 @@
+../../test/test_httpd_shared_helm_imagestreams.py

--- a/2.4-micro/test/test_httpd_shared_helm_template.py
+++ b/2.4-micro/test/test_httpd_shared_helm_template.py
@@ -1,0 +1,1 @@
+../../test/test_httpd_shared_helm_template.py

--- a/2.4/test/test_httpd_helm_chart_imagestreams.py
+++ b/2.4/test/test_httpd_helm_chart_imagestreams.py
@@ -1,1 +1,0 @@
-../../test/test_httpd_helm_chart_imagestreams.py

--- a/2.4/test/test_httpd_helm_chart_template.py
+++ b/2.4/test/test_httpd_helm_chart_template.py
@@ -1,1 +1,0 @@
-../../test/test_httpd_helm_chart_template.py

--- a/2.4/test/test_httpd_shared_helm_imagestreams.py
+++ b/2.4/test/test_httpd_shared_helm_imagestreams.py
@@ -1,0 +1,1 @@
+../../test/test_httpd_shared_helm_imagestreams.py

--- a/2.4/test/test_httpd_shared_helm_template.py
+++ b/2.4/test/test_httpd_shared_helm_template.py
@@ -1,0 +1,1 @@
+../../test/test_httpd_shared_helm_template.py

--- a/test/test_httpd_shared_helm_imagestreams.py
+++ b/test/test_httpd_shared_helm_imagestreams.py
@@ -13,7 +13,7 @@ class TestHelmRHELHttpdImageStreams:
     def setup_method(self):
         package_name = "httpd-imagestreams"
         path = test_dir
-        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir, remote=True)
+        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir)
         self.hc_api.clone_helm_chart_repo(
             repo_url="https://github.com/sclorg/helm-charts", repo_name="helm-charts",
             subdir="charts/redhat"

--- a/test/test_httpd_shared_helm_template.py
+++ b/test/test_httpd_shared_helm_template.py
@@ -25,7 +25,7 @@ class TestHelmHTTPDTemplate:
     def setup_method(self):
         package_name = "httpd-template"
         path = test_dir
-        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir, remote=True)
+        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir)
         self.hc_api.clone_helm_chart_repo(
             repo_url="https://github.com/sclorg/helm-charts", repo_name="helm-charts",
             subdir="charts/redhat"


### PR DESCRIPTION
Rename PyTest files so helm tests are executed as the last.

Container-ci-suite still do not support switching between cluster


<!-- issue-commentator = {"comment-id":"2459499832"} -->







































































<!-- testing-farm = {"lock":"false","comment-id":"2459511457","data":[{"id":"bc6079f9-aa29-4e3a-aa45-0241b455e319","name":"CentOS Stream 9 - 2.4","status":"complete","outcome":"passed","runTime":339.26586,"created":"2024-11-06T11:29:23.869774","updated":"2024-11-06T11:29:23.869781","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/bc6079f9-aa29-4e3a-aa45-0241b455e319\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/bc6079f9-aa29-4e3a-aa45-0241b455e319/pipeline.log\">pipeline</a>"]},{"id":"289b5800-1f8a-4072-b093-72598d0474ab","name":"CentOS Stream 9 - 2.4-micro","status":"complete","outcome":"passed","runTime":405.308444,"created":"2024-11-06T11:29:33.250752","updated":"2024-11-06T11:29:33.250760","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/289b5800-1f8a-4072-b093-72598d0474ab\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/289b5800-1f8a-4072-b093-72598d0474ab/pipeline.log\">pipeline</a>"]},{"id":"298ccdcf-347d-4ade-9185-23dd64a54258","name":"Fedora - 2.4","status":"complete","outcome":"passed","runTime":473.869087,"created":"2024-11-06T11:29:24.304334","updated":"2024-11-06T11:29:24.304340","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/298ccdcf-347d-4ade-9185-23dd64a54258\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/298ccdcf-347d-4ade-9185-23dd64a54258/pipeline.log\">pipeline</a>"]},{"id":"e59262ec-c852-4124-b641-f057995ae6bf","name":"CentOS Stream 10 - 2.4-micro","status":"complete","outcome":"passed","runTime":485.836517,"created":"2024-11-06T11:29:24.100302","updated":"2024-11-06T11:29:24.100309","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/e59262ec-c852-4124-b641-f057995ae6bf\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/e59262ec-c852-4124-b641-f057995ae6bf/pipeline.log\">pipeline</a>"]},{"id":"8cba6b42-2ff5-4451-81ef-422063c6a9e4","name":"Fedora - 2.4-micro","status":"complete","outcome":"passed","runTime":518.999998,"created":"2024-11-06T11:29:24.605929","updated":"2024-11-06T11:29:24.605935","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/8cba6b42-2ff5-4451-81ef-422063c6a9e4\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/8cba6b42-2ff5-4451-81ef-422063c6a9e4/pipeline.log\">pipeline</a>"]},{"id":"410f23c0-a684-41ea-af88-6bdae0164ff3","name":"CentOS Stream 10 - 2.4","status":"complete","outcome":"passed","runTime":528.332456,"created":"2024-11-06T11:29:24.501733","updated":"2024-11-06T11:29:24.501742","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/410f23c0-a684-41ea-af88-6bdae0164ff3\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/410f23c0-a684-41ea-af88-6bdae0164ff3/pipeline.log\">pipeline</a>"]},{"id":"c83ecba5-9d31-419e-a6be-402b01a3a1d6","name":"RHEL9 - 2.4","status":"complete","outcome":"passed","runTime":929.873871,"created":"2024-11-06T11:29:24.721964","updated":"2024-11-06T11:29:24.721971","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c83ecba5-9d31-419e-a6be-402b01a3a1d6\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c83ecba5-9d31-419e-a6be-402b01a3a1d6/pipeline.log\">pipeline</a>"]},{"id":"1b31f280-4b27-47fd-b96f-5c6f1cd79f7c","name":"RHEL9 - OpenShift 4 - 2.4","status":"complete","outcome":"passed","runTime":973.196635,"created":"2024-11-06T11:29:42.101767","updated":"2024-11-06T11:29:42.101774","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1b31f280-4b27-47fd-b96f-5c6f1cd79f7c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1b31f280-4b27-47fd-b96f-5c6f1cd79f7c/pipeline.log\">pipeline</a>"]},{"id":"e3651b57-0c91-4dc8-a285-c24da2b651ca","name":"RHEL8 - 2.4","status":"complete","outcome":"passed","runTime":1059.191584,"created":"2024-11-06T11:29:36.811857","updated":"2024-11-06T11:29:36.811864","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e3651b57-0c91-4dc8-a285-c24da2b651ca\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e3651b57-0c91-4dc8-a285-c24da2b651ca/pipeline.log\">pipeline</a>"]},{"id":"7a2af101-8ca4-4f29-9925-f1d8153a40f6","name":"RHEL8 - OpenShift 4 - 2.4","status":"complete","outcome":"passed","runTime":1179.585539,"created":"2024-11-06T11:29:55.167020","updated":"2024-11-06T11:29:55.167027","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7a2af101-8ca4-4f29-9925-f1d8153a40f6\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7a2af101-8ca4-4f29-9925-f1d8153a40f6/pipeline.log\">pipeline</a>"]},{"id":"8e572f42-6a60-4d9e-9d1e-4bdcd6e364f8","name":"RHEL9 - PyTest - OpenShift 4 - 2.4","status":"complete","outcome":"passed","runTime":1228.189628,"created":"2024-11-06T11:29:48.962999","updated":"2024-11-06T11:29:48.963006","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8e572f42-6a60-4d9e-9d1e-4bdcd6e364f8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8e572f42-6a60-4d9e-9d1e-4bdcd6e364f8/pipeline.log\">pipeline</a>"]},{"id":"0ad64e67-3e62-46e4-a62a-fc8025e7346a","name":"RHEL8 - PyTest - OpenShift 4 - 2.4","runTime":1281.072863,"created":"2024-11-06T11:29:51.129779","updated":"2024-11-06T11:29:51.129802","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0ad64e67-3e62-46e4-a62a-fc8025e7346a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0ad64e67-3e62-46e4-a62a-fc8025e7346a/pipeline.log\">pipeline</a>"]}]} -->