### PR TITLE
Add support for testing httpd-container by Container PyTest

### DIFF
--- a/.github/workflows/container-pytests.yml
+++ b/.github/workflows/container-pytests.yml
@@ -1,0 +1,30 @@
+on:
+  issue_comment:
+    types:
+      - created
+jobs:
+  container-tests:
+    name: "Container PyTest: ${{ matrix.version }} - ${{ matrix.os_test }}"
+    runs-on: ubuntu-20.04
+    concurrency:
+      group: container-${{ github.event.issue.number }}-${{ matrix.version }}-${{ matrix.os_test }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
+        version: [ "2.4", "2.4-micro" ]
+        os_test: [ "fedora", "rhel8", "rhel9", "c9s", "c10s" ]
+        test_case: [ "container-pytest" ]
+
+    if: |
+      github.event.issue.pull_request
+      && (contains(github.event.comment.body, '[test-pytest]') || contains(github.event.comment.body, '[test-all]'))
+      && contains(fromJson('["OWNER", "MEMBER"]'), github.event.comment.author_association)
+    steps:
+      - uses: sclorg/tfaga-wrapper@main
+        with:
+          os_test: ${{ matrix.os_test }}
+          version: ${{ matrix.version }}
+          test_case: ${{ matrix.test_case }}
+          public_api_key: ${{ secrets.TF_PUBLIC_API_KEY }}
+          private_api_key: ${{ secrets.TF_INTERNAL_API_KEY }}


### PR DESCRIPTION
This pull request adds support for testing httpd-container by Container Pytest suite.

It is updated only GitHub Action.


<!-- issue-commentator = {"comment-id":"2514657771"} -->