### PR TITLE
Helm charts have been renamed to 'redhat-' suffix.

### DIFF
--- a/test/test_httpd_shared_helm_imagestreams.py
+++ b/test/test_httpd_shared_helm_imagestreams.py
@@ -11,7 +11,7 @@ test_dir = Path(os.path.abspath(os.path.dirname(__file__)))
 class TestHelmRHELHttpdImageStreams:
 
     def setup_method(self):
-        package_name = "httpd-imagestreams"
+        package_name = "redhat-httpd-imagestreams"
         path = test_dir
         self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir)
         self.hc_api.clone_helm_chart_repo(

--- a/test/test_httpd_shared_helm_template.py
+++ b/test/test_httpd_shared_helm_template.py
@@ -23,7 +23,7 @@ TAG = TAGS.get(OS, None)
 class TestHelmHTTPDTemplate:
 
     def setup_method(self):
-        package_name = "httpd-template"
+        package_name = "redhat-httpd-template"
         path = test_dir
         self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir)
         self.hc_api.clone_helm_chart_repo(
@@ -40,10 +40,10 @@ class TestHelmHTTPDTemplate:
         new_version = VERSION
         if "micro" in VERSION:
             new_version = VERSION.replace("-micro", "")
-        self.hc_api.package_name = "httpd-imagestreams"
+        self.hc_api.package_name = "redhat-httpd-imagestreams"
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation()
-        self.hc_api.package_name = "httpd-template"
+        self.hc_api.package_name = "redhat-httpd-template"
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation(
             values={
@@ -61,10 +61,10 @@ class TestHelmHTTPDTemplate:
         new_version = VERSION
         if "micro" in VERSION:
             new_version = VERSION.replace("-micro", "")
-        self.hc_api.package_name = "httpd-imagestreams"
+        self.hc_api.package_name = "redhat-httpd-imagestreams"
         self.hc_api.helm_package()
         assert self.hc_api.helm_installation()
-        self.hc_api.package_name = "httpd-template"
+        self.hc_api.package_name = "redhat-httpd-template"
         self.hc_api.helm_package()
         assert self.hc_api.helm_installation(
             values={


### PR DESCRIPTION
The helm charts for httpd was renamed to prefix 'redhat-' so the structure is the same as in https://github.com/openshift-helm-chart/charts repository
