### PR TITLE
Fix helm chart tests

### DIFF
--- a/test/test_httpd_ex_template.py
+++ b/test/test_httpd_ex_template.py
@@ -23,7 +23,7 @@ class TestHTTPDExExampleRepo:
 
     def setup_method(self):
         self.template_name = get_service_image(IMAGE_NAME)
-        self.oc_api = OpenShiftAPI(pod_name_prefix=self.template_name, version=VERSION)
+        self.oc_api = OpenShiftAPI(pod_name_prefix=self.template_name, version=VERSION, shared_cluster=True)
 
     def teardown_method(self):
         self.oc_api.delete_project()

--- a/test/test_httpd_shared_helm_imagestreams.py
+++ b/test/test_httpd_shared_helm_imagestreams.py
@@ -11,7 +11,7 @@ test_dir = Path(os.path.abspath(os.path.dirname(__file__)))
 class TestHelmRHELHttpdImageStreams:
 
     def setup_method(self):
-        package_name = "httpd-imagestreams"
+        package_name = "redhat-httpd-imagestreams"
         path = test_dir
         self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir)
         self.hc_api.clone_helm_chart_repo(

--- a/test/test_httpd_shared_helm_imagestreams.py
+++ b/test/test_httpd_shared_helm_imagestreams.py
@@ -13,7 +13,7 @@ class TestHelmRHELHttpdImageStreams:
     def setup_method(self):
         package_name = "redhat-httpd-imagestreams"
         path = test_dir
-        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir)
+        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir, shared_cluster=True)
         self.hc_api.clone_helm_chart_repo(
             repo_url="https://github.com/sclorg/helm-charts", repo_name="helm-charts",
             subdir="charts/redhat"

--- a/test/test_httpd_shared_helm_template.py
+++ b/test/test_httpd_shared_helm_template.py
@@ -23,7 +23,7 @@ TAG = TAGS.get(OS, None)
 class TestHelmHTTPDTemplate:
 
     def setup_method(self):
-        package_name = "httpd-template"
+        package_name = "redhat-httpd-template"
         path = test_dir
         self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir)
         self.hc_api.clone_helm_chart_repo(
@@ -40,10 +40,10 @@ class TestHelmHTTPDTemplate:
         new_version = VERSION
         if "micro" in VERSION:
             new_version = VERSION.replace("-micro", "")
-        self.hc_api.package_name = "httpd-imagestreams"
+        self.hc_api.package_name = "redhat-httpd-imagestreams"
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation()
-        self.hc_api.package_name = "httpd-template"
+        self.hc_api.package_name = "redhat-httpd-template"
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation(
             values={
@@ -61,10 +61,10 @@ class TestHelmHTTPDTemplate:
         new_version = VERSION
         if "micro" in VERSION:
             new_version = VERSION.replace("-micro", "")
-        self.hc_api.package_name = "httpd-imagestreams"
+        self.hc_api.package_name = "redhat-httpd-imagestreams"
         self.hc_api.helm_package()
         assert self.hc_api.helm_installation()
-        self.hc_api.package_name = "httpd-template"
+        self.hc_api.package_name = "redhat-httpd-template"
         self.hc_api.helm_package()
         assert self.hc_api.helm_installation(
             values={

--- a/test/test_httpd_shared_helm_template.py
+++ b/test/test_httpd_shared_helm_template.py
@@ -52,9 +52,9 @@ class TestHelmHTTPDTemplate:
             }
         )
         assert self.hc_api.is_s2i_pod_running(pod_name_prefix="httpd-example")
-        assert self.hc_api.test_helm_curl_output(
-            route_name="httpd-example",
-            expected_str="Welcome to your static httpd application on OpenShift"
+        assert self.hc_api.oc_api.check_response_inside_cluster(
+            name_in_template="httpd-example",
+            expected_output="Welcome to your static httpd application on OpenShift"
         )
 
     def test_package_persistent_by_helm_chart_test(self):


### PR DESCRIPTION
<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->


<!-- issue-commentator = {"comment-id":"2656643891"} -->





















































































<!-- testing-farm = {"lock":"false","comment-id":"2656663627","data":[{"id":"e625df2b-f5d3-40cf-8eaf-858a33766113","name":"Fedora - 2.4","status":"complete","outcome":"passed","runTime":429.583218,"created":"2025-02-13T13:44:05.602556","updated":"2025-02-13T13:44:05.602562","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/e625df2b-f5d3-40cf-8eaf-858a33766113\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/e625df2b-f5d3-40cf-8eaf-858a33766113/pipeline.log\">pipeline</a>"]},{"id":"023a8fcb-a30b-4b00-aad6-97d92917e754","name":"Fedora - 2.4-micro","status":"complete","outcome":"passed","runTime":430.216517,"created":"2025-02-13T13:44:09.602200","updated":"2025-02-13T13:44:09.602209","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/023a8fcb-a30b-4b00-aad6-97d92917e754\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/023a8fcb-a30b-4b00-aad6-97d92917e754/pipeline.log\">pipeline</a>"]},{"id":"912221fd-e1aa-46d0-9dee-6fcce5e4393c","name":"CentOS Stream 10 - 2.4-micro","status":"complete","outcome":"passed","runTime":463.963155,"created":"2025-02-13T13:44:09.768570","updated":"2025-02-13T13:44:09.768579","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/912221fd-e1aa-46d0-9dee-6fcce5e4393c\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/912221fd-e1aa-46d0-9dee-6fcce5e4393c/pipeline.log\">pipeline</a>"]},{"id":"de496fb9-c293-4c5c-ad41-44b30e4e937e","name":"CentOS Stream 9 - 2.4-micro","status":"complete","outcome":"passed","runTime":544.487624,"created":"2025-02-13T13:44:08.709055","updated":"2025-02-13T13:44:08.709063","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/de496fb9-c293-4c5c-ad41-44b30e4e937e\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/de496fb9-c293-4c5c-ad41-44b30e4e937e/pipeline.log\">pipeline</a>"]},{"id":"9944e454-d37b-4fa3-84fc-96337f374418","name":"CentOS Stream 9 - 2.4","status":"complete","outcome":"passed","runTime":554.411872,"created":"2025-02-13T13:44:07.879992","updated":"2025-02-13T13:44:07.880000","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/9944e454-d37b-4fa3-84fc-96337f374418\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/9944e454-d37b-4fa3-84fc-96337f374418/pipeline.log\">pipeline</a>"]},{"id":"f90b67ec-1f1f-4272-b3c6-36651ce75507","name":"RHEL10 - 2.4","status":"complete","outcome":"passed","runTime":4834.915554,"created":"2025-02-13T13:44:08.742220","updated":"2025-02-13T13:44:08.742228","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f90b67ec-1f1f-4272-b3c6-36651ce75507\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f90b67ec-1f1f-4272-b3c6-36651ce75507/pipeline.log\">pipeline</a>"]},{"id":"d4e528c1-d9b7-41b1-b933-c22c6b6e1bda","name":"RHEL9 - 2.4","status":"complete","outcome":"passed","runTime":4838.400692,"created":"2025-02-13T13:44:09.022353","updated":"2025-02-13T13:44:09.022361","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d4e528c1-d9b7-41b1-b933-c22c6b6e1bda\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d4e528c1-d9b7-41b1-b933-c22c6b6e1bda/pipeline.log\">pipeline</a>"]},{"id":"eef4346a-115a-477c-b394-60a5ef08b944","name":"RHEL10 - OpenShift 4 - 2.4","status":"complete","outcome":"passed","runTime":4870.661716,"created":"2025-02-13T13:44:21.987078","updated":"2025-02-13T13:44:21.987087","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/eef4346a-115a-477c-b394-60a5ef08b944\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/eef4346a-115a-477c-b394-60a5ef08b944/pipeline.log\">pipeline</a>"]},{"id":"3c794ea4-f463-4488-a269-b47942a01e71","name":"RHEL9 - OpenShift 4 - 2.4","status":"complete","outcome":"passed","runTime":5006.33806,"created":"2025-02-13T13:44:19.727263","updated":"2025-02-13T13:44:19.727271","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3c794ea4-f463-4488-a269-b47942a01e71\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3c794ea4-f463-4488-a269-b47942a01e71/pipeline.log\">pipeline</a>"]},{"id":"6f95f3a9-0c66-4403-877d-1f8f41aab427","name":"RHEL8 - 2.4","status":"complete","outcome":"passed","runTime":5087.582391,"created":"2025-02-13T13:44:09.794447","updated":"2025-02-13T13:44:09.794454","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6f95f3a9-0c66-4403-877d-1f8f41aab427\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6f95f3a9-0c66-4403-877d-1f8f41aab427/pipeline.log\">pipeline</a>"]},{"id":"12442422-3c0e-4f2a-b7f6-b250de74f2e6","name":"RHEL8 - OpenShift 4 - 2.4","status":"complete","outcome":"passed","runTime":5145.705516,"created":"2025-02-13T13:44:19.082371","updated":"2025-02-13T13:44:19.082378","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/12442422-3c0e-4f2a-b7f6-b250de74f2e6\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/12442422-3c0e-4f2a-b7f6-b250de74f2e6/pipeline.log\">pipeline</a>"]},{"id":"e03a87fb-c872-48ef-b46a-694179b2acdb","name":"RHEL8 - PyTest - OpenShift 4 - 2.4","status":"complete","outcome":"passed","runTime":5491.218972,"created":"2025-02-13T13:44:21.321276","updated":"2025-02-13T13:44:21.321288","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e03a87fb-c872-48ef-b46a-694179b2acdb\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e03a87fb-c872-48ef-b46a-694179b2acdb/pipeline.log\">pipeline</a>"]},{"id":"c0fa4bc8-ef83-4531-ab03-4ada0626c191","name":"RHEL9 - PyTest - OpenShift 4 - 2.4","status":"complete","outcome":"passed","runTime":5500.084791,"created":"2025-02-13T13:44:21.507996","updated":"2025-02-13T13:44:21.508008","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c0fa4bc8-ef83-4531-ab03-4ada0626c191\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c0fa4bc8-ef83-4531-ab03-4ada0626c191/pipeline.log\">pipeline</a>"]},{"id":"82b5f70b-c378-4848-9c85-83de1130a2a4","name":"RHEL10 - PyTest - OpenShift 4 - 2.4","runTime":5654.968695,"created":"2025-02-13T13:44:23.121580","updated":"2025-02-13T13:44:23.121587","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"error","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/82b5f70b-c378-4848-9c85-83de1130a2a4\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/82b5f70b-c378-4848-9c85-83de1130a2a4/pipeline.log\">pipeline</a>"]}]} -->