### PR TITLE
Enable testing httpd-container on shared cluster.

### DIFF
--- a/test/test_httpd_imagestream_s2i.py
+++ b/test/test_httpd_imagestream_s2i.py
@@ -20,7 +20,7 @@ class TestHTTPDImagestreamS2I:
 
     def setup_method(self):
         self.template_name = get_service_image(IMAGE_NAME)
-        self.oc_api = OpenShiftAPI(pod_name_prefix=self.template_name, version=VERSION)
+        self.oc_api = OpenShiftAPI(pod_name_prefix=self.template_name, version=VERSION, shared_cluster=True)
 
     def teardown_method(self):
         self.oc_api.delete_project()

--- a/test/test_httpd_imagestream_s2i.py
+++ b/test/test_httpd_imagestream_s2i.py
@@ -26,6 +26,8 @@ class TestHTTPDImagestreamS2I:
         self.oc_api.delete_project()
 
     def test_inside_cluster(self):
+        if VERSION == "rhel10":
+            pytest.skip("Do NOT test on RHEL10.")
         os_name = ''.join(i for i in OS if not i.isdigit())
         assert self.oc_api.deploy_imagestream_s2i(
             imagestream_file=f"imagestreams/httpd-{os_name}.json",

--- a/test/test_httpd_integration.py
+++ b/test/test_httpd_integration.py
@@ -20,7 +20,7 @@ class TestHTTPDIntegrationTemplate:
 
     def setup_method(self):
         self.template_name = get_service_image(IMAGE_NAME)
-        self.oc_api = OpenShiftAPI(pod_name_prefix=self.template_name, version=VERSION)
+        self.oc_api = OpenShiftAPI(pod_name_prefix=self.template_name, version=VERSION, shared_cluster=True)
 
     def teardown_method(self):
         self.oc_api.delete_project()

--- a/test/test_httpd_shared_helm_template.py
+++ b/test/test_httpd_shared_helm_template.py
@@ -25,7 +25,7 @@ class TestHelmHTTPDTemplate:
     def setup_method(self):
         package_name = "redhat-httpd-template"
         path = test_dir
-        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir)
+        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir, shared_cluster=True)
         self.hc_api.clone_helm_chart_repo(
             repo_url="https://github.com/sclorg/helm-charts", repo_name="helm-charts",
             subdir="charts/redhat"

--- a/test/test_httpd_shared_helm_template.py
+++ b/test/test_httpd_shared_helm_template.py
@@ -58,6 +58,8 @@ class TestHelmHTTPDTemplate:
         )
 
     def test_package_persistent_by_helm_chart_test(self):
+        if OS == "rhel10":
+            pytest.skip("Do NOT test on RHEL10.")
         new_version = VERSION
         if "micro" in VERSION:
             new_version = VERSION.replace("-micro", "")


### PR DESCRIPTION
This pull request enables testing httpd-container on shared cluster.
Everything is driven by internal file as semaphore.

<!-- issue-commentator = {"comment-id":"2697518319"} -->







































































<!-- testing-farm = {"lock":"false","comment-id":"2697985919","data":[{"id":"d40d66a7-b0e1-4d8a-8247-a26530eccaad","name":"RHEL10 - OpenShift 4 - 2.4","status":"complete","outcome":"passed","runTime":889.146938,"created":"2025-03-04T15:27:34.931722","updated":"2025-03-04T15:27:34.931728","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d40d66a7-b0e1-4d8a-8247-a26530eccaad\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d40d66a7-b0e1-4d8a-8247-a26530eccaad/pipeline.log\">pipeline</a>"]},{"id":"7f1bfda2-d2b4-477b-a02d-afce21b12dca","name":"RHEL9 - PyTest - OpenShift 4 - 2.4","status":"complete","outcome":"passed","runTime":1086.939224,"created":"2025-03-04T15:27:36.667290","updated":"2025-03-04T15:27:36.667303","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7f1bfda2-d2b4-477b-a02d-afce21b12dca\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7f1bfda2-d2b4-477b-a02d-afce21b12dca/pipeline.log\">pipeline</a>"]},{"id":"31b919bf-e8c7-4dd0-85d5-26f15ff85e1c","name":"RHEL10 - PyTest - OpenShift 4 - 2.4","status":"complete","outcome":"passed","runTime":1037.626111,"created":"2025-03-04T15:27:38.779476","updated":"2025-03-04T15:27:38.779484","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/31b919bf-e8c7-4dd0-85d5-26f15ff85e1c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/31b919bf-e8c7-4dd0-85d5-26f15ff85e1c/pipeline.log\">pipeline</a>"]},{"id":"0e2a6760-ac54-48f0-a3ea-7c52e7598f96","name":"RHEL9 - OpenShift 4 - 2.4","status":"complete","outcome":"passed","runTime":954.471339,"created":"2025-03-04T15:27:37.821939","updated":"2025-03-04T15:27:37.821946","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0e2a6760-ac54-48f0-a3ea-7c52e7598f96\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0e2a6760-ac54-48f0-a3ea-7c52e7598f96/pipeline.log\">pipeline</a>"]},{"id":"35c187c6-891d-4155-84ad-3fec5f8c4fc8","name":"RHEL8 - OpenShift 4 - 2.4","status":"complete","outcome":"passed","runTime":1143.706929,"created":"2025-03-04T15:27:34.236754","updated":"2025-03-04T15:27:34.236761","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/35c187c6-891d-4155-84ad-3fec5f8c4fc8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/35c187c6-891d-4155-84ad-3fec5f8c4fc8/pipeline.log\">pipeline</a>"]},{"id":"d061dfa5-27a5-405f-aa32-01f11b6d154d","name":"RHEL8 - PyTest - OpenShift 4 - 2.4","runTime":1332.758322,"created":"2025-03-04T15:27:35.734695","updated":"2025-03-04T15:27:35.734702","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d061dfa5-27a5-405f-aa32-01f11b6d154d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d061dfa5-27a5-405f-aa32-01f11b6d154d/pipeline.log\">pipeline</a>"]}]} -->