### PR TITLE
Rename package bind-utils to bind9.18-utils

### DIFF
--- a/2.4/Dockerfile.rhel9
+++ b/2.4/Dockerfile.rhel9
@@ -35,7 +35,7 @@ LABEL summary="$SUMMARY" \
 EXPOSE 8080
 EXPOSE 8443
 
-RUN INSTALL_PKGS="gettext hostname nss_wrapper-libs bind-utils httpd mod_ssl mod_ldap mod_session mod_security mod_auth_mellon sscg" && \
+RUN INSTALL_PKGS="gettext hostname nss_wrapper-libs bind9.18-utils httpd mod_ssl mod_ldap mod_session mod_security mod_auth_mellon sscg" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     httpd -v | grep -qe "Apache/$HTTPD_VERSION" && echo "Found VERSION $HTTPD_VERSION" && \


### PR DESCRIPTION
Rename package bind-utils to bind9.18-utils

See Jira Ticket: https://issues.redhat.com/browse/RHEL-80345

<!-- issue-commentator = {"comment-id":"2747310362"} -->

<!-- testing-farm = {"lock":"false","comment-id":"2747321843","data":[{"id":"b11d1a0d-1b66-40b4-9c06-a2cd0e8f7410","name":"CentOS Stream 10 - 2.4-micro","status":"complete","outcome":"passed","runTime":307.534446,"created":"2025-03-24T08:38:38.658515","updated":"2025-03-24T08:38:38.658522","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/b11d1a0d-1b66-40b4-9c06-a2cd0e8f7410\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/b11d1a0d-1b66-40b4-9c06-a2cd0e8f7410/pipeline.log\">pipeline</a>"]},{"id":"0980db9e-7fda-4de4-91f6-aeb4c0243078","name":"CentOS Stream 9 - 2.4","status":"complete","outcome":"passed","runTime":354.505692,"created":"2025-03-24T08:39:17.926855","updated":"2025-03-24T08:39:17.926861","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/0980db9e-7fda-4de4-91f6-aeb4c0243078\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/0980db9e-7fda-4de4-91f6-aeb4c0243078/pipeline.log\">pipeline</a>"]},{"id":"e6f1725f-025e-4fc2-a583-aa07d4bd5b90","name":"CentOS Stream 10 - 2.4","status":"complete","outcome":"passed","runTime":323.532432,"created":"2025-03-24T08:40:00.902435","updated":"2025-03-24T08:40:00.902441","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/e6f1725f-025e-4fc2-a583-aa07d4bd5b90\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/e6f1725f-025e-4fc2-a583-aa07d4bd5b90/pipeline.log\">pipeline</a>"]},{"id":"ac6c170e-c3b7-441b-9043-fcfd2f7ce9fb","name":"CentOS Stream 9 - 2.4-micro","status":"complete","outcome":"passed","runTime":343.144845,"created":"2025-03-24T08:39:29.637361","updated":"2025-03-24T08:39:29.637368","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/ac6c170e-c3b7-441b-9043-fcfd2f7ce9fb\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/ac6c170e-c3b7-441b-9043-fcfd2f7ce9fb/pipeline.log\">pipeline</a>"]},{"id":"036fb3dd-768e-4ab9-8a22-38819aa431e8","name":"Fedora - 2.4","status":"complete","outcome":"passed","runTime":458.912788,"created":"2025-03-24T08:39:33.100204","updated":"2025-03-24T08:39:33.100211","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/036fb3dd-768e-4ab9-8a22-38819aa431e8\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/036fb3dd-768e-4ab9-8a22-38819aa431e8/pipeline.log\">pipeline</a>"]},{"id":"0cd63803-ebfc-4170-8224-eb3e1c4318b2","name":"Fedora - 2.4-micro","status":"complete","outcome":"passed","runTime":503.582627,"created":"2025-03-24T08:39:41.036556","updated":"2025-03-24T08:39:41.036563","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/0cd63803-ebfc-4170-8224-eb3e1c4318b2\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/0cd63803-ebfc-4170-8224-eb3e1c4318b2/pipeline.log\">pipeline</a>"]},{"id":"4fbc1e3a-e1f4-4604-93cf-99a611e4cefa","name":"RHEL9 - 2.4","status":"complete","outcome":"passed","runTime":791.744549,"created":"2025-03-24T08:38:53.253219","updated":"2025-03-24T08:38:53.253226","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4fbc1e3a-e1f4-4604-93cf-99a611e4cefa\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4fbc1e3a-e1f4-4604-93cf-99a611e4cefa/pipeline.log\">pipeline</a>"]},{"id":"8ddafb5b-7697-4b94-9439-9552887f6e16","name":"RHEL10 - OpenShift 4 - 2.4","status":"complete","outcome":"passed","runTime":862.359135,"created":"2025-03-24T08:38:35.028896","updated":"2025-03-24T08:38:35.028903","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8ddafb5b-7697-4b94-9439-9552887f6e16\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8ddafb5b-7697-4b94-9439-9552887f6e16/pipeline.log\">pipeline</a>"]},{"id":"f1899c61-6be6-4a8b-86ed-f75f45c4beab","name":"RHEL10 - 2.4","status":"complete","outcome":"passed","runTime":836.913637,"created":"2025-03-24T08:39:09.374046","updated":"2025-03-24T08:39:09.374053","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f1899c61-6be6-4a8b-86ed-f75f45c4beab\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f1899c61-6be6-4a8b-86ed-f75f45c4beab/pipeline.log\">pipeline</a>"]},{"id":"b9710527-b477-493c-bddc-a2d2aa208208","name":"RHEL9 - OpenShift 4 - 2.4","status":"complete","outcome":"passed","runTime":927.863601,"created":"2025-03-24T08:39:14.989345","updated":"2025-03-24T08:39:14.989351","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b9710527-b477-493c-bddc-a2d2aa208208\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b9710527-b477-493c-bddc-a2d2aa208208/pipeline.log\">pipeline</a>"]},{"id":"bfa05bc9-d456-4742-9e95-69b5b966beba","name":"RHEL8 - 2.4","status":"complete","outcome":"passed","runTime":963.589275,"created":"2025-03-24T08:39:25.317243","updated":"2025-03-24T08:39:25.317255","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/bfa05bc9-d456-4742-9e95-69b5b966beba\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/bfa05bc9-d456-4742-9e95-69b5b966beba/pipeline.log\">pipeline</a>"]},{"id":"5770d715-f70d-4adf-bf30-2b87f0febefb","name":"RHEL8 - OpenShift 4 - 2.4","runTime":1152.308673,"created":"2025-03-24T08:40:04.458142","updated":"2025-03-24T08:40:04.458149","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5770d715-f70d-4adf-bf30-2b87f0febefb\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5770d715-f70d-4adf-bf30-2b87f0febefb/pipeline.log\">pipeline</a>"]}]} -->