### PR TITLE
S2I Imagestreams does not work in Shared Cluster

### DIFF
--- a/test/test_httpd_ex_template.py
+++ b/test/test_httpd_ex_template.py
@@ -23,7 +23,7 @@ class TestHTTPDExExampleRepo:
 
     def setup_method(self):
         self.template_name = get_service_image(IMAGE_NAME)
-        self.oc_api = OpenShiftAPI(pod_name_prefix=self.template_name, version=VERSION, shared_cluster=True)
+        self.oc_api = OpenShiftAPI(pod_name_prefix=self.template_name, version=VERSION)
 
     def teardown_method(self):
         self.oc_api.delete_project()
@@ -34,7 +34,7 @@ class TestHTTPDExExampleRepo:
             app=f"https://github.com/sclorg/httpd-ex#{BRANCH_TO_TEST}",
             context="."
         )
-        assert self.oc_api.template_deployed(name_in_template=self.template_name)
+        assert self.oc_api.is_template_deployed(name_in_template=self.template_name)
         assert self.oc_api.check_response_inside_cluster(
             name_in_template=self.template_name, expected_output="Welcome to your static httpd"
         )

--- a/test/test_httpd_imagestream_s2i.py
+++ b/test/test_httpd_imagestream_s2i.py
@@ -20,7 +20,7 @@ class TestHTTPDImagestreamS2I:
 
     def setup_method(self):
         self.template_name = get_service_image(IMAGE_NAME)
-        self.oc_api = OpenShiftAPI(pod_name_prefix=self.template_name, version=VERSION, shared_cluster=True)
+        self.oc_api = OpenShiftAPI(pod_name_prefix=self.template_name, version=VERSION)
 
     def teardown_method(self):
         self.oc_api.delete_project()
@@ -33,9 +33,10 @@ class TestHTTPDImagestreamS2I:
             imagestream_file=f"imagestreams/httpd-{os_name}.json",
             image_name=IMAGE_NAME,
             app="https://github.com/sclorg/httpd-container.git",
-            context="examples/sample-test-app"
+            context="examples/sample-test-app",
+            service_name=self.template_name
         )
-        assert self.oc_api.template_deployed(name_in_template=self.template_name)
+        assert self.oc_api.is_s2i_pod_running(pod_name_prefix=self.template_name)
         assert self.oc_api.check_response_inside_cluster(
             name_in_template=self.template_name, expected_output="This is a sample s2i application with static content"
         )

--- a/test/test_httpd_integration.py
+++ b/test/test_httpd_integration.py
@@ -20,7 +20,7 @@ class TestHTTPDIntegrationTemplate:
 
     def setup_method(self):
         self.template_name = get_service_image(IMAGE_NAME)
-        self.oc_api = OpenShiftAPI(pod_name_prefix=self.template_name, version=VERSION, shared_cluster=True)
+        self.oc_api = OpenShiftAPI(pod_name_prefix=self.template_name, version=VERSION)
 
     def teardown_method(self):
         self.oc_api.delete_project()
@@ -31,7 +31,7 @@ class TestHTTPDIntegrationTemplate:
             app=f"https://github.com/sclorg/httpd-container.git",
             context="examples/sample-test-app"
         )
-        assert self.oc_api.template_deployed(name_in_template=self.template_name)
+        assert self.oc_api.is_template_deployed(name_in_template=self.template_name)
         assert self.oc_api.check_response_inside_cluster(
             name_in_template=self.template_name, expected_output="This is a sample s2i application with static content"
         )


### PR DESCRIPTION
Let's disable it for know. As soon as build is done, then deployment is not caught the new build image.

<!-- issue-commentator = {"comment-id":"2765915338"} -->

<!-- testing-farm = {"lock":"false","comment-id":"2765943453","data":[{"id":"b48559d9-6062-4270-8e4a-49ac914b10a2","name":"RHEL10 - OpenShift 4 - 2.4","status":"complete","outcome":"passed","runTime":927.798458,"created":"2025-04-03T11:35:40.329221","updated":"2025-04-03T11:35:40.329228","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b48559d9-6062-4270-8e4a-49ac914b10a2\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b48559d9-6062-4270-8e4a-49ac914b10a2/pipeline.log\">pipeline</a>"]},{"id":"7feed7b1-4592-4e21-a8df-610c0ff7a757","name":"RHEL9 - OpenShift 4 - 2.4","status":"complete","outcome":"passed","runTime":1252.011899,"created":"2025-04-03T11:35:38.984899","updated":"2025-04-03T11:35:38.984905","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7feed7b1-4592-4e21-a8df-610c0ff7a757\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7feed7b1-4592-4e21-a8df-610c0ff7a757/pipeline.log\">pipeline</a>"]},{"id":"379c8d2a-95b9-4df5-9b6d-cd19e4ec90ba","name":"RHEL8 - OpenShift 4 - 2.4","status":"complete","outcome":"passed","runTime":1225.598028,"created":"2025-04-03T11:35:39.958301","updated":"2025-04-03T11:35:39.958307","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/379c8d2a-95b9-4df5-9b6d-cd19e4ec90ba\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/379c8d2a-95b9-4df5-9b6d-cd19e4ec90ba/pipeline.log\">pipeline</a>"]},{"id":"c03b0825-270d-4e19-859a-25eb48ea7337","name":"RHEL10 - PyTest - OpenShift 4 - 2.4","status":"complete","outcome":"passed","runTime":2102.516429,"created":"2025-04-03T11:36:00.969263","updated":"2025-04-03T11:36:00.969272","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c03b0825-270d-4e19-859a-25eb48ea7337\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c03b0825-270d-4e19-859a-25eb48ea7337/pipeline.log\">pipeline</a>"]},{"id":"a94287b1-1072-44bb-8d34-4299e440bdba","name":"RHEL9 - PyTest - OpenShift 4 - 2.4","status":"complete","outcome":"passed","runTime":2237.192157,"created":"2025-04-03T11:35:59.258676","updated":"2025-04-03T11:35:59.258682","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a94287b1-1072-44bb-8d34-4299e440bdba\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a94287b1-1072-44bb-8d34-4299e440bdba/pipeline.log\">pipeline</a>"]},{"id":"01866250-051e-448b-8a09-ee107b254e1b","name":"RHEL8 - PyTest - OpenShift 4 - 2.4","runTime":2544.504511,"created":"2025-04-03T11:35:58.639637","updated":"2025-04-03T11:35:58.639643","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/01866250-051e-448b-8a09-ee107b254e1b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/01866250-051e-448b-8a09-ee107b254e1b/pipeline.log\">pipeline</a>"]}]} -->