### PR TITLE
Disable cron for aut-merge-on-demand

### DIFF
--- a/.github/workflows/auto-merge-on-demand.yml
+++ b/.github/workflows/auto-merge-on-demand.yml
@@ -1,8 +1,8 @@
-name: Auto Merge Scheduled / On Demand
+name: Auto Merge On Demand
 on:
-  schedule:
-    # Workflow runs every 45 minutes
-    - cron: '*/45 * * * *'
+  issue_comment:
+    types:
+      - created
   workflow_dispatch:
     inputs:
       pr-number:
@@ -16,7 +16,10 @@ permissions:
 jobs:
   # Get all open PRs
   gather-pull-requests:
-    if: github.repository_owner == 'sclorg'
+    if: |
+      github.repository_owner == 'sclorg'
+      || (contains(github.event.comment.body, '/auto-merge')
+      && contains(fromJson('["OWNER", "MEMBER"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest
 
     outputs:
@@ -44,7 +47,7 @@ jobs:
         name: Parse manual input
         run: |
           # shellcheck disable=SC2086
-          echo "result="[ ${{ inputs.pr-number }} ]"" >> $GITHUB_OUTPUT
+          echo "result="[ ${{ github.event.issue.number }} ]"" >> $GITHUB_OUTPUT
         shell: bash
 
   validate-pr:


### PR DESCRIPTION
Disable cron for aut-merge-on-demand

Call it on request /auto-merge in comment.

Scheduler blocks our actions.



<!-- issue-commentator = {"comment-id":"2919239004"} -->

<!-- testing-farm = {"lock":"false","comment-id":"2919227910","data":[{"id":"4b59587a-42eb-46ec-ad90-29a655275fc3","name":"CentOS Stream 9 - 2.4-micro","status":"complete","outcome":"passed","runTime":489.856744,"created":"2025-05-29T12:10:19.926641","updated":"2025-05-29T12:10:19.926647","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/4b59587a-42eb-46ec-ad90-29a655275fc3\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/4b59587a-42eb-46ec-ad90-29a655275fc3/pipeline.log\">pipeline</a>"]},{"id":"c0ddee4d-2f80-4e2f-8b17-b7cdf2e73495","name":"Fedora - 2.4-micro","status":"complete","outcome":"passed","runTime":521.916245,"created":"2025-05-29T12:12:41.282490","updated":"2025-05-29T12:12:41.282496","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/c0ddee4d-2f80-4e2f-8b17-b7cdf2e73495\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/c0ddee4d-2f80-4e2f-8b17-b7cdf2e73495/pipeline.log\">pipeline</a>"]},{"id":"2c3fb672-f1de-4a16-a215-6a6effd5323a","name":"CentOS Stream 10 - 2.4-micro","status":"complete","outcome":"passed","runTime":312.591358,"created":"2025-05-29T12:24:00.684358","updated":"2025-05-29T12:24:00.684364","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/2c3fb672-f1de-4a16-a215-6a6effd5323a\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/2c3fb672-f1de-4a16-a215-6a6effd5323a/pipeline.log\">pipeline</a>"]},{"id":"a4d93e61-4b39-469a-921b-3c1904c4c9b2","name":"CentOS Stream 10 - 2.4","status":"complete","outcome":"passed","runTime":368.20137,"created":"2025-05-29T12:23:46.563655","updated":"2025-05-29T12:23:46.563663","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/a4d93e61-4b39-469a-921b-3c1904c4c9b2\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/a4d93e61-4b39-469a-921b-3c1904c4c9b2/pipeline.log\">pipeline</a>"]},{"id":"a6ce4f91-8c3d-4945-abb6-e6aa47a63faa","name":"Fedora - 2.4","status":"complete","outcome":"passed","runTime":482.597893,"created":"2025-05-29T12:24:49.787780","updated":"2025-05-29T12:24:49.787786","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/a6ce4f91-8c3d-4945-abb6-e6aa47a63faa\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/a6ce4f91-8c3d-4945-abb6-e6aa47a63faa/pipeline.log\">pipeline</a>"]},{"id":"e22be14a-b127-4432-9b64-46245798c4fe","name":"CentOS Stream 9 - 2.4","status":"complete","outcome":"passed","runTime":510.690376,"created":"2025-05-29T12:24:27.100563","updated":"2025-05-29T12:24:27.100569","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/e22be14a-b127-4432-9b64-46245798c4fe\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/e22be14a-b127-4432-9b64-46245798c4fe/pipeline.log\">pipeline</a>"]},{"id":"be3c0b09-15fa-47bd-9fd5-f5b3bc451709","name":"RHEL10 - 2.4","status":"complete","outcome":"passed","runTime":748.857085,"created":"2025-05-29T12:24:42.111889","updated":"2025-05-29T12:24:42.111895","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/be3c0b09-15fa-47bd-9fd5-f5b3bc451709\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/be3c0b09-15fa-47bd-9fd5-f5b3bc451709/pipeline.log\">pipeline</a>"]},{"id":"96e87739-3ea0-4e97-bcfb-30500397bad0","name":"RHEL8 - 2.4","status":"complete","outcome":"passed","runTime":886.626226,"created":"2025-05-29T12:24:13.577148","updated":"2025-05-29T12:24:13.577155","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/96e87739-3ea0-4e97-bcfb-30500397bad0\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/96e87739-3ea0-4e97-bcfb-30500397bad0/pipeline.log\">pipeline</a>"]},{"id":"24f83e42-4a95-4762-8366-e3e9daf6d9f6","name":"RHEL9 - 2.4","runTime":955.644461,"created":"2025-05-29T12:24:39.243176","updated":"2025-05-29T12:24:39.243182","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/24f83e42-4a95-4762-8366-e3e9daf6d9f6\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/24f83e42-4a95-4762-8366-e3e9daf6d9f6/pipeline.log\">pipeline</a>"]}]} -->