### PR TITLE
Fix regular expression used for proper imagestream

### DIFF
--- a/test/test-lib-httpd.sh
+++ b/test/test-lib-httpd.sh
@@ -20,12 +20,7 @@ function test_httpd_integration() {
 
 # Check the imagestream
 function test_httpd_imagestream() {
-  case ${OS} in
-    rhel8|rhel9) ;;
-    *) echo "Imagestream testing not supported for $OS environment." ; return 0 ;;
-  esac
-
-  ct_os_test_image_stream_s2i "${THISDIR}/imagestreams/httpd-${OS%[0-9]*}.json" "${IMAGE_NAME}" \
+  ct_os_test_image_stream_s2i "${THISDIR}/imagestreams/httpd-${OS//[0-9]/}.json" "${IMAGE_NAME}" \
                               "https://github.com/sclorg/httpd-container.git" \
                               "examples/sample-test-app" \
                               "This is a sample s2i application with static content"


### PR DESCRIPTION
Fix regular expression used for proper imagestream

rhel9 works fine.
For rhel10 it returns rhel1 that is wrong.

Allow also checking imagestreams for rhel10

