### PR TITLE
Remove 'version' label from Dockerfile.rhel10

### DIFF
--- a/2.4/Dockerfile.rhel10
+++ b/2.4/Dockerfile.rhel10
@@ -27,7 +27,6 @@ LABEL summary="${SUMMARY}" \
       io.openshift.expose-services="8080:http,8443:https" \
       io.openshift.tags="builder,${NAME},${NAME}-${HTTPD_SHORT_VERSION}" \
       name="ubi10/${NAME}-${HTTPD_SHORT_VERSION}" \
-      version="1" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI" \
       com.redhat.component="${NAME}-${HTTPD_SHORT_VERSION}-container" \
       usage="s2i build https://github.com/sclorg/httpd-container.git --context-dir=examples/sample-test-app/ ubi10/${NAME}-${HTTPD_SHORT_VERSION} sample-server" \


### PR DESCRIPTION
Remove 'version' label from Dockerfile.rhel10

Konflux build pipeline needs it.
See https://issues.redhat.com/browse/RHELMISC-17288

<!-- issue-commentator = {"comment-id":"3279144035"} -->

<!-- testing-farm = {"lock":"false","comment-id":"3279207036","data":[{"id":"f6b4837b-7494-422d-ad51-043ef8c6a5db","name":"Fedora - 2.4","status":"complete","outcome":"passed","runTime":426.743037,"created":"2025-09-11T08:30:04.325584","updated":"2025-09-11T08:30:04.325590","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/f6b4837b-7494-422d-ad51-043ef8c6a5db\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/f6b4837b-7494-422d-ad51-043ef8c6a5db/pipeline.log\">pipeline</a>"]},{"id":"5cdd9b77-a14b-472d-8ab4-9adfd46282e8","name":"Fedora - 2.4-micro","status":"complete","outcome":"passed","runTime":524.438886,"created":"2025-09-11T08:29:56.564821","updated":"2025-09-11T08:29:56.564827","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/5cdd9b77-a14b-472d-8ab4-9adfd46282e8\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/5cdd9b77-a14b-472d-8ab4-9adfd46282e8/pipeline.log\">pipeline</a>"]},{"id":"44b2d060-1c9b-4d62-a8c7-9ea0b1c3804e","name":"CentOS Stream 10 - 2.4-micro","status":"complete","outcome":"passed","runTime":540.464108,"created":"2025-09-11T08:30:04.898697","updated":"2025-09-11T08:30:04.898703","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/44b2d060-1c9b-4d62-a8c7-9ea0b1c3804e\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/44b2d060-1c9b-4d62-a8c7-9ea0b1c3804e/pipeline.log\">pipeline</a>"]},{"id":"a310f9a9-24b5-42a8-945f-e58b6464f2cc","name":"CentOS Stream 9 - 2.4","status":"complete","outcome":"passed","runTime":608.109192,"created":"2025-09-11T08:30:06.468478","updated":"2025-09-11T08:30:06.468484","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/a310f9a9-24b5-42a8-945f-e58b6464f2cc\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/a310f9a9-24b5-42a8-945f-e58b6464f2cc/pipeline.log\">pipeline</a>"]},{"id":"16a9da7d-97db-4622-a370-804d7e606a11","name":"RHEL10 - 2.4","status":"complete","outcome":"passed","runTime":767.504865,"created":"2025-09-11T08:30:01.499538","updated":"2025-09-11T08:30:01.499543","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/16a9da7d-97db-4622-a370-804d7e606a11\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/16a9da7d-97db-4622-a370-804d7e606a11/pipeline.log\">pipeline</a>"]},{"id":"faace480-54ef-42dc-98c3-b956d0b9a013","name":"RHEL8 - 2.4","status":"complete","outcome":"passed","runTime":954.554278,"created":"2025-09-11T08:29:55.854290","updated":"2025-09-11T08:29:55.854296","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/faace480-54ef-42dc-98c3-b956d0b9a013\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/faace480-54ef-42dc-98c3-b956d0b9a013/pipeline.log\">pipeline</a>"]},{"id":"70609c73-c910-49d1-a85c-d2fde3563a7c","name":"CentOS Stream 9 - 2.4-micro","status":"complete","outcome":"passed","runTime":638.722337,"created":"2025-09-11T08:37:28.535644","updated":"2025-09-11T08:37:28.535650","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/70609c73-c910-49d1-a85c-d2fde3563a7c\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/70609c73-c910-49d1-a85c-d2fde3563a7c/pipeline.log\">pipeline</a>"]},{"id":"19ae8f7e-878b-4bb6-bb67-14e069d61fb5","name":"RHEL9 - 2.4","runTime":1132.100838,"created":"2025-09-11T08:29:57.128035","updated":"2025-09-11T08:29:57.128042","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/19ae8f7e-878b-4bb6-bb67-14e069d61fb5\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/19ae8f7e-878b-4bb6-bb67-14e069d61fb5/pipeline.log\">pipeline</a>"]}]} -->