### PR TITLE
Fix Listen directive to not hard-code IPv4 (fixes #287)

### DIFF
--- a/2.4-micro/root/usr/share/container-scripts/httpd/common.sh
+++ b/2.4-micro/root/usr/share/container-scripts/httpd/common.sh
@@ -58,9 +58,9 @@ EOF
 }
 
 config_general() {
-  sed -i -e 's/^Listen 80/Listen 0.0.0.0:8080/' ${HTTPD_MAIN_CONF_PATH}/httpd.conf && \
+  sed -i -e 's/^Listen 80/Listen 8080/' ${HTTPD_MAIN_CONF_PATH}/httpd.conf && \
   sed -i -e ${HTTPCONF_LINENO}'s%AllowOverride None%AllowOverride All%' ${HTTPD_MAIN_CONF_PATH}/httpd.conf && \
-  sed -i -e 's/^Listen 443/Listen 0.0.0.0:8443/' ${HTTPD_MAIN_CONF_D_PATH}/ssl.conf
+  sed -i -e 's/^Listen 443/Listen 8443/' ${HTTPD_MAIN_CONF_D_PATH}/ssl.conf
   sed -i -e 's/_default_:443/_default_:8443/' ${HTTPD_MAIN_CONF_D_PATH}/ssl.conf
 
   # do sed for SSLCertificateFile and SSLCertificateKeyFile

--- a/2.4/root/usr/share/container-scripts/httpd/common.sh
+++ b/2.4/root/usr/share/container-scripts/httpd/common.sh
@@ -64,9 +64,9 @@ EOF
 }
 
 config_general() {
-  sed -i -e 's/^Listen 80/Listen 0.0.0.0:8080/' ${HTTPD_MAIN_CONF_PATH}/httpd.conf && \
+  sed -i -e 's/^Listen 80/Listen 8080/' ${HTTPD_MAIN_CONF_PATH}/httpd.conf && \
   sed -i -e ${HTTPCONF_LINENO}'s%AllowOverride None%AllowOverride All%' ${HTTPD_MAIN_CONF_PATH}/httpd.conf && \
-  sed -i -e 's/^Listen 443/Listen 0.0.0.0:8443/' ${HTTPD_MAIN_CONF_D_PATH}/ssl.conf
+  sed -i -e 's/^Listen 443/Listen 8443/' ${HTTPD_MAIN_CONF_D_PATH}/ssl.conf
   sed -i -e 's/_default_:443/_default_:8443/' ${HTTPD_MAIN_CONF_D_PATH}/ssl.conf
 
   # do sed for SSLCertificateFile and SSLCertificateKeyFile


### PR DESCRIPTION
<!-- issue-commentator = {"comment-id":"4176238995"} -->

<!-- testing-farm = {"lock":"false","comment-id":"4178116713","data":[{"id":"3a21176a-81c4-47db-aba7-1becf021dbb9","name":"Fedora - 2.4","status":"complete","outcome":"passed","runTime":405.821902,"created":"2026-04-02T13:54:30.048657","updated":"2026-04-02T13:54:30.048666","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/3a21176a-81c4-47db-aba7-1becf021dbb9\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/3a21176a-81c4-47db-aba7-1becf021dbb9/pipeline.log\">pipeline</a>"]},{"id":"572b065d-3084-4fb6-b87c-ad269f44bb2b","name":"Fedora - 2.4-micro","status":"complete","outcome":"passed","runTime":392.878789,"created":"2026-04-02T13:54:31.671711","updated":"2026-04-02T13:54:31.671719","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/572b065d-3084-4fb6-b87c-ad269f44bb2b\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/572b065d-3084-4fb6-b87c-ad269f44bb2b/pipeline.log\">pipeline</a>"]},{"id":"8ecdd104-1b1b-4c72-9ad0-57f97d3c8087","name":"CentOS Stream 10 - PyTest - 2.4-micro","status":"complete","outcome":"passed","runTime":576.216,"created":"2026-04-02T13:54:31.412465","updated":"2026-04-02T13:54:31.412473","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/8ecdd104-1b1b-4c72-9ad0-57f97d3c8087\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/8ecdd104-1b1b-4c72-9ad0-57f97d3c8087/pipeline.log\">pipeline</a>"]},{"id":"cd69454a-f81a-40a5-b83e-04c77167f917","name":"CentOS Stream 9 - 2.4-micro","status":"complete","outcome":"passed","runTime":601.41516,"created":"2026-04-02T13:54:30.073909","updated":"2026-04-02T13:54:30.073917","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/cd69454a-f81a-40a5-b83e-04c77167f917\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/cd69454a-f81a-40a5-b83e-04c77167f917/pipeline.log\">pipeline</a>"]},{"id":"7cc5f750-9853-4fd7-9fb2-7e7bf3c1b242","name":"CentOS Stream 9 - PyTest - 2.4-micro","status":"complete","outcome":"passed","runTime":590.123683,"created":"2026-04-02T13:54:32.706069","updated":"2026-04-02T13:54:32.706076","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/7cc5f750-9853-4fd7-9fb2-7e7bf3c1b242\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/7cc5f750-9853-4fd7-9fb2-7e7bf3c1b242/pipeline.log\">pipeline</a>"]},{"id":"11fbdbb0-b441-4e7c-af30-2d075e77a043","name":"CentOS Stream 10 - 2.4","status":"complete","outcome":"passed","runTime":582.30227,"created":"2026-04-02T13:54:57.058353","updated":"2026-04-02T13:54:57.058360","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/11fbdbb0-b441-4e7c-af30-2d075e77a043\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/11fbdbb0-b441-4e7c-af30-2d075e77a043/pipeline.log\">pipeline</a>"]},{"id":"a9f870cf-a731-423d-9790-ac6c4ae9f300","name":"CentOS Stream 10 - PyTest - 2.4","status":"complete","outcome":"passed","runTime":621.18623,"created":"2026-04-02T13:54:30.358293","updated":"2026-04-02T13:54:30.358300","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/a9f870cf-a731-423d-9790-ac6c4ae9f300\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/a9f870cf-a731-423d-9790-ac6c4ae9f300/pipeline.log\">pipeline</a>"]},{"id":"fd2df2cc-d19e-4fd7-8f78-d644368a4d33","name":"RHEL8 - 2.4","status":"complete","outcome":"passed","runTime":780.705849,"created":"2026-04-02T13:54:31.113378","updated":"2026-04-02T13:54:31.113385","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/fd2df2cc-d19e-4fd7-8f78-d644368a4d33\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/fd2df2cc-d19e-4fd7-8f78-d644368a4d33/pipeline.log\">pipeline</a>"]},{"id":"d6aecec6-40e7-412a-be3a-392a555a1031","name":"RHEL10 - 2.4","status":"complete","outcome":"passed","runTime":948.720118,"created":"2026-04-02T13:54:30.119603","updated":"2026-04-02T13:54:30.119610","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d6aecec6-40e7-412a-be3a-392a555a1031\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d6aecec6-40e7-412a-be3a-392a555a1031/pipeline.log\">pipeline</a>"]},{"id":"d6132231-62a3-4b4f-8b95-fd16786ae36f","name":"RHEL10 - Unsubscribed host - PyTest - 2.4","status":"complete","outcome":"passed","runTime":873.738287,"created":"2026-04-02T13:54:30.021164","updated":"2026-04-02T13:54:30.021171","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d6132231-62a3-4b4f-8b95-fd16786ae36f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d6132231-62a3-4b4f-8b95-fd16786ae36f/pipeline.log\">pipeline</a>"]},{"id":"a96b4dfa-4f99-47ac-b19d-1d15df34bca8","name":"RHEL10 - Unsubscribed host - 2.4","status":"complete","outcome":"passed","runTime":889.148461,"created":"2026-04-02T13:54:30.955242","updated":"2026-04-02T13:54:30.955251","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a96b4dfa-4f99-47ac-b19d-1d15df34bca8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a96b4dfa-4f99-47ac-b19d-1d15df34bca8/pipeline.log\">pipeline</a>"]},{"id":"9445e247-7c56-46e9-9822-9cb650dc3221","name":"RHEL10 - PyTest - 2.4","status":"complete","outcome":"passed","runTime":911.220426,"created":"2026-04-02T13:54:29.918242","updated":"2026-04-02T13:54:29.918249","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9445e247-7c56-46e9-9822-9cb650dc3221\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9445e247-7c56-46e9-9822-9cb650dc3221/pipeline.log\">pipeline</a>"]},{"id":"3d6fafd2-6535-4120-a53c-95b77b39d7f2","name":"Fedora - PyTest - 2.4","status":"complete","outcome":"passed","runTime":379.394704,"created":"2026-04-02T14:02:51.842719","updated":"2026-04-02T14:02:51.842726","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/3d6fafd2-6535-4120-a53c-95b77b39d7f2\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/3d6fafd2-6535-4120-a53c-95b77b39d7f2/pipeline.log\">pipeline</a>"]},{"id":"83a15897-2399-433e-83b8-0c169b91eabc","name":"RHEL9 - Unsubscribed host - 2.4","status":"complete","outcome":"passed","runTime":1049.055024,"created":"2026-04-02T13:54:30.633384","updated":"2026-04-02T13:54:30.633390","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/83a15897-2399-433e-83b8-0c169b91eabc\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/83a15897-2399-433e-83b8-0c169b91eabc/pipeline.log\">pipeline</a>"]},{"id":"92375a5a-38fe-4ada-8afb-ea3ccd0b5862","name":"RHEL9 - Unsubscribed host - PyTest - 2.4","status":"complete","outcome":"passed","runTime":1025.615597,"created":"2026-04-02T13:54:31.636101","updated":"2026-04-02T13:54:31.636325","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/92375a5a-38fe-4ada-8afb-ea3ccd0b5862\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/92375a5a-38fe-4ada-8afb-ea3ccd0b5862/pipeline.log\">pipeline</a>"]},{"id":"7a407874-31f1-4e9f-bae1-b57132968a8d","name":"RHEL9 - PyTest - 2.4","status":"complete","outcome":"passed","runTime":1184.970211,"created":"2026-04-02T13:54:29.812195","updated":"2026-04-02T13:54:29.812202","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7a407874-31f1-4e9f-bae1-b57132968a8d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7a407874-31f1-4e9f-bae1-b57132968a8d/pipeline.log\">pipeline</a>"]},{"id":"2fd1c999-8a1c-4a79-be88-c25908818986","name":"RHEL9 - 2.4","status":"complete","outcome":"passed","runTime":1250.768153,"created":"2026-04-02T13:54:31.963399","updated":"2026-04-02T13:54:31.963406","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2fd1c999-8a1c-4a79-be88-c25908818986\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2fd1c999-8a1c-4a79-be88-c25908818986/pipeline.log\">pipeline</a>"]},{"id":"857a43a0-ec05-45c6-8aa1-40d6c81721c0","name":"RHEL8 - PyTest - 2.4","status":"complete","outcome":"passed","runTime":924.287516,"created":"2026-04-02T14:02:49.256216","updated":"2026-04-02T14:02:49.256225","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/857a43a0-ec05-45c6-8aa1-40d6c81721c0\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/857a43a0-ec05-45c6-8aa1-40d6c81721c0/pipeline.log\">pipeline</a>"]},{"id":"2b172172-54f8-4045-8a11-627b720933e0","name":"RHEL10 - PyTest - OpenShift 4 - 2.4","status":"complete","outcome":"passed","runTime":1379.270476,"created":"2026-04-02T14:02:53.667158","updated":"2026-04-02T14:02:53.667167","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2b172172-54f8-4045-8a11-627b720933e0\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2b172172-54f8-4045-8a11-627b720933e0/pipeline.log\">pipeline</a>"]},{"id":"5fe4b776-04ab-40ed-8dd4-4d4005dbac63","name":"RHEL8 - PyTest - OpenShift 4 - 2.4","status":"complete","outcome":"error","runTime":1552.206477,"created":"2026-04-02T14:04:52.345686","updated":"2026-04-02T14:04:52.345693","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5fe4b776-04ab-40ed-8dd4-4d4005dbac63\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5fe4b776-04ab-40ed-8dd4-4d4005dbac63/pipeline.log\">pipeline</a>"]},{"id":"d6d3c385-4e71-422a-a135-3982fe82e52c","name":"RHEL9 - PyTest - OpenShift 4 - 2.4","runTime":1774.616349,"created":"2026-04-02T14:04:51.111099","updated":"2026-04-02T14:04:51.111104","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"error","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d6d3c385-4e71-422a-a135-3982fe82e52c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d6d3c385-4e71-422a-a135-3982fe82e52c/pipeline.log\">pipeline</a>"]}]} -->