### PR TITLE
(fix): Use end of line anchor on sed to make it idempotent

### DIFF
--- a/2.4-micro/root/usr/share/container-scripts/httpd/common.sh
+++ b/2.4-micro/root/usr/share/container-scripts/httpd/common.sh
@@ -58,7 +58,7 @@ EOF
 }
 
 config_general() {
-  sed -i -e 's/^Listen 80/Listen 8080/' ${HTTPD_MAIN_CONF_PATH}/httpd.conf && \
+  sed -i -e 's/^Listen 80$/Listen 8080/' ${HTTPD_MAIN_CONF_PATH}/httpd.conf && \
   sed -i -e ${HTTPCONF_LINENO}'s%AllowOverride None%AllowOverride All%' ${HTTPD_MAIN_CONF_PATH}/httpd.conf && \
   sed -i -e 's/^Listen 443/Listen 8443/' ${HTTPD_MAIN_CONF_D_PATH}/ssl.conf
   sed -i -e 's/_default_:443/_default_:8443/' ${HTTPD_MAIN_CONF_D_PATH}/ssl.conf

--- a/2.4/root/usr/share/container-scripts/httpd/common.sh
+++ b/2.4/root/usr/share/container-scripts/httpd/common.sh
@@ -64,7 +64,7 @@ EOF
 }
 
 config_general() {
-  sed -i -e 's/^Listen 80/Listen 8080/' ${HTTPD_MAIN_CONF_PATH}/httpd.conf && \
+  sed -i -e 's/^Listen 80$/Listen 8080/' ${HTTPD_MAIN_CONF_PATH}/httpd.conf && \
   sed -i -e ${HTTPCONF_LINENO}'s%AllowOverride None%AllowOverride All%' ${HTTPD_MAIN_CONF_PATH}/httpd.conf && \
   sed -i -e 's/^Listen 443/Listen 8443/' ${HTTPD_MAIN_CONF_D_PATH}/ssl.conf
   sed -i -e 's/_default_:443/_default_:8443/' ${HTTPD_MAIN_CONF_D_PATH}/ssl.conf


### PR DESCRIPTION
Fixes https://github.com/sclorg/httpd-container/issues/289

<!-- issue-commentator = {"comment-id":"4245288563"} -->

<!-- testing-farm = {"lock":"false","comment-id":"4245368607","data":[{"id":"0f73b362-7f43-41df-9d71-c29ab671d2bd","name":"Fedora - PyTest - 2.4","status":"complete","outcome":"passed","runTime":451.172044,"created":"2026-04-14T15:54:10.153637","updated":"2026-04-14T15:54:10.153644","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/0f73b362-7f43-41df-9d71-c29ab671d2bd\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/0f73b362-7f43-41df-9d71-c29ab671d2bd/pipeline.log\">pipeline</a>"]},{"id":"03c9ede7-9a47-408d-87d2-b8b57c5ad0e5","name":"Fedora - PyTest - 2.4-micro","status":"complete","outcome":"passed","runTime":478.490364,"created":"2026-04-14T15:54:09.920962","updated":"2026-04-14T15:54:09.920970","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/03c9ede7-9a47-408d-87d2-b8b57c5ad0e5\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/03c9ede7-9a47-408d-87d2-b8b57c5ad0e5/pipeline.log\">pipeline</a>"]},{"id":"3a196857-f719-452d-92f2-9246a948e11a","name":"Fedora - 2.4-micro","status":"complete","outcome":"passed","runTime":479.236131,"created":"2026-04-14T15:54:13.019654","updated":"2026-04-14T15:54:13.019661","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/3a196857-f719-452d-92f2-9246a948e11a\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/3a196857-f719-452d-92f2-9246a948e11a/pipeline.log\">pipeline</a>"]},{"id":"5980a46d-0c9f-45c5-852b-386ee3050f2c","name":"Fedora - 2.4","status":"complete","outcome":"passed","runTime":507.515029,"created":"2026-04-14T15:54:10.216442","updated":"2026-04-14T15:54:10.216448","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/5980a46d-0c9f-45c5-852b-386ee3050f2c\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/5980a46d-0c9f-45c5-852b-386ee3050f2c/pipeline.log\">pipeline</a>"]},{"id":"6475abf1-edda-4add-a6d7-b9314b209dd5","name":"CentOS Stream 9 - 2.4-micro","status":"complete","outcome":"passed","runTime":662.466715,"created":"2026-04-14T15:54:12.645040","updated":"2026-04-14T15:54:12.645046","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/6475abf1-edda-4add-a6d7-b9314b209dd5\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/6475abf1-edda-4add-a6d7-b9314b209dd5/pipeline.log\">pipeline</a>"]},{"id":"33b8ddd5-e71a-48fe-9246-a9032dc7e66e","name":"CentOS Stream 10 - PyTest - 2.4","status":"complete","outcome":"passed","runTime":602.626446,"created":"2026-04-14T15:54:13.066322","updated":"2026-04-14T15:54:13.066330","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/33b8ddd5-e71a-48fe-9246-a9032dc7e66e\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/33b8ddd5-e71a-48fe-9246-a9032dc7e66e/pipeline.log\">pipeline</a>"]},{"id":"0e7b0f45-f5fc-4080-8d47-71e26929e439","name":"CentOS Stream 9 - PyTest - 2.4-micro","status":"complete","outcome":"passed","runTime":656.890134,"created":"2026-04-14T15:54:11.280573","updated":"2026-04-14T15:54:11.280581","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/0e7b0f45-f5fc-4080-8d47-71e26929e439\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/0e7b0f45-f5fc-4080-8d47-71e26929e439/pipeline.log\">pipeline</a>"]},{"id":"ecd10a58-db4c-40ad-8787-930b44d9124c","name":"CentOS Stream 10 - 2.4-micro","status":"complete","outcome":"passed","runTime":676.41735,"created":"2026-04-14T15:54:10.331306","updated":"2026-04-14T15:54:10.331312","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/ecd10a58-db4c-40ad-8787-930b44d9124c\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/ecd10a58-db4c-40ad-8787-930b44d9124c/pipeline.log\">pipeline</a>"]},{"id":"a7a7b2b7-3bef-40bf-a526-f78b0202a79f","name":"RHEL8 - PyTest - 2.4","status":"complete","outcome":"passed","runTime":863.717138,"created":"2026-04-14T15:54:13.104806","updated":"2026-04-14T15:54:13.104812","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a7a7b2b7-3bef-40bf-a526-f78b0202a79f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a7a7b2b7-3bef-40bf-a526-f78b0202a79f/pipeline.log\">pipeline</a>"]},{"id":"eab673e3-9ba7-45e3-99e8-cd749176096d","name":"RHEL8 - 2.4","status":"complete","outcome":"passed","runTime":901.647247,"created":"2026-04-14T15:54:13.186827","updated":"2026-04-14T15:54:13.186834","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/eab673e3-9ba7-45e3-99e8-cd749176096d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/eab673e3-9ba7-45e3-99e8-cd749176096d/pipeline.log\">pipeline</a>"]},{"id":"a617e8b5-81c8-4fbc-b67f-b9ff2cebd45c","name":"RHEL10 - 2.4","status":"complete","outcome":"passed","runTime":1062.253763,"created":"2026-04-14T15:54:10.301310","updated":"2026-04-14T15:54:10.301316","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a617e8b5-81c8-4fbc-b67f-b9ff2cebd45c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a617e8b5-81c8-4fbc-b67f-b9ff2cebd45c/pipeline.log\">pipeline</a>"]},{"id":"cf4bfe88-6b74-4079-bc6f-952288b5cf06","name":"RHEL10 - Unsubscribed host - PyTest - 2.4","status":"complete","outcome":"passed","runTime":1069.298923,"created":"2026-04-14T15:54:13.975939","updated":"2026-04-14T15:54:13.975947","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/cf4bfe88-6b74-4079-bc6f-952288b5cf06\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/cf4bfe88-6b74-4079-bc6f-952288b5cf06/pipeline.log\">pipeline</a>"]},{"id":"b9e9d11d-38f8-4d16-b212-c0020a2a5032","name":"RHEL10 - Unsubscribed host - 2.4","status":"complete","outcome":"passed","runTime":1009.472745,"created":"2026-04-14T15:54:12.414630","updated":"2026-04-14T15:54:12.414637","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b9e9d11d-38f8-4d16-b212-c0020a2a5032\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b9e9d11d-38f8-4d16-b212-c0020a2a5032/pipeline.log\">pipeline</a>"]},{"id":"54f2e539-8cd7-40f2-889e-e3b2647f915f","name":"CentOS Stream 9 - PyTest - 2.4","status":"complete","outcome":"passed","runTime":572.445101,"created":"2026-04-14T16:02:26.082200","updated":"2026-04-14T16:02:26.082206","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/54f2e539-8cd7-40f2-889e-e3b2647f915f\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/54f2e539-8cd7-40f2-889e-e3b2647f915f/pipeline.log\">pipeline</a>"]},{"id":"cb3e1899-62be-4306-b125-8501bb0c3bde","name":"CentOS Stream 9 - 2.4","status":"complete","outcome":"passed","runTime":579.671818,"created":"2026-04-14T16:02:36.318705","updated":"2026-04-14T16:02:36.318733","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/cb3e1899-62be-4306-b125-8501bb0c3bde\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/cb3e1899-62be-4306-b125-8501bb0c3bde/pipeline.log\">pipeline</a>"]},{"id":"cd12f9bf-a58e-4cd0-82fc-d88eff18ca8c","name":"RHEL10 - PyTest - 2.4","status":"complete","outcome":"passed","runTime":1117.243322,"created":"2026-04-14T15:54:11.286216","updated":"2026-04-14T15:54:11.286222","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/cd12f9bf-a58e-4cd0-82fc-d88eff18ca8c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/cd12f9bf-a58e-4cd0-82fc-d88eff18ca8c/pipeline.log\">pipeline</a>"]},{"id":"32c5fe73-d946-46e5-85b9-95a976519383","name":"RHEL9 - Unsubscribed host - PyTest - 2.4","status":"complete","outcome":"passed","runTime":1194.919282,"created":"2026-04-14T15:54:13.100021","updated":"2026-04-14T15:54:13.100028","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/32c5fe73-d946-46e5-85b9-95a976519383\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/32c5fe73-d946-46e5-85b9-95a976519383/pipeline.log\">pipeline</a>"]},{"id":"d4812796-90b4-4dc9-92b1-05b1d02b8ad4","name":"RHEL9 - PyTest - 2.4","status":"complete","outcome":"passed","runTime":1229.068127,"created":"2026-04-14T15:54:10.179349","updated":"2026-04-14T15:54:10.179355","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d4812796-90b4-4dc9-92b1-05b1d02b8ad4\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d4812796-90b4-4dc9-92b1-05b1d02b8ad4/pipeline.log\">pipeline</a>"]},{"id":"096a2ed1-9c26-4e68-ae0a-e0b65ff4856f","name":"RHEL9 - 2.4","status":"complete","outcome":"passed","runTime":1396.944062,"created":"2026-04-14T15:54:31.305388","updated":"2026-04-14T15:54:31.305395","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/096a2ed1-9c26-4e68-ae0a-e0b65ff4856f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/096a2ed1-9c26-4e68-ae0a-e0b65ff4856f/pipeline.log\">pipeline</a>"]},{"id":"495aec9a-9fa6-4957-bf00-3f426a288a8a","name":"RHEL8 - PyTest - OpenShift 4 - 2.4","status":"complete","outcome":"passed","runTime":1196.364454,"created":"2026-04-15T10:22:12.367500","updated":"2026-04-15T10:22:12.367506","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/495aec9a-9fa6-4957-bf00-3f426a288a8a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/495aec9a-9fa6-4957-bf00-3f426a288a8a/pipeline.log\">pipeline</a>"]},{"id":"f28f6b32-76c4-46ce-be3f-38664c88fd27","name":"RHEL10 - PyTest - OpenShift 4 - 2.4","status":"complete","outcome":"passed","runTime":1363.757301,"created":"2026-04-15T10:22:11.216684","updated":"2026-04-15T10:22:11.216693","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f28f6b32-76c4-46ce-be3f-38664c88fd27\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f28f6b32-76c4-46ce-be3f-38664c88fd27/pipeline.log\">pipeline</a>"]},{"id":"1624f3fb-7a45-43a9-8b14-b6ae754bfa1a","name":"RHEL9 - PyTest - OpenShift 4 - 2.4","runTime":1544.512119,"created":"2026-04-15T10:22:10.363457","updated":"2026-04-15T10:22:10.363464","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1624f3fb-7a45-43a9-8b14-b6ae754bfa1a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1624f3fb-7a45-43a9-8b14-b6ae754bfa1a/pipeline.log\">pipeline</a>"]}]} -->