### PR TITLE
Let' use shared_cluster based on share_cluster.json variable and update PyTest

### DIFF
--- a/2.4-micro/test/conftest.py
+++ b/2.4-micro/test/conftest.py
@@ -1,0 +1,1 @@
+../../test/conftest.py

--- a/2.4-micro/test/constants.py
+++ b/2.4-micro/test/constants.py
@@ -1,1 +1,0 @@
-../../test/constants.py

--- a/2.4/test/conftest.py
+++ b/2.4/test/conftest.py
@@ -1,0 +1,1 @@
+../../test/conftest.py

--- a/2.4/test/constants.py
+++ b/2.4/test/constants.py
@@ -1,1 +1,0 @@
-../../test/constants.py

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -23,7 +23,6 @@ Vars = namedtuple(
         "TAG",
         "VERSION",
         "IMAGE_NAME",
-        "SHORT_VERSION",
         "TEST_DIR",
     ],
 )
@@ -35,6 +34,5 @@ VARS = Vars(
     TAG=TAGS.get(OS),
     VERSION=VERSION,
     IMAGE_NAME=os.getenv("IMAGE_NAME"),
-    SHORT_VERSION=VERSION.replace(".", ""),
     TEST_DIR=TEST_DIR,
 )

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,40 @@
+import os
+import sys
+
+from pathlib import Path
+from collections import namedtuple
+
+from container_ci_suite.utils import check_variables
+
+if not check_variables():
+    sys.exit(1)
+
+TAGS = {
+    "rhel8": "-ubi8",
+    "rhel9": "-ubi9",
+    "rhel10": "-ubi10",
+}
+
+TEST_DIR = Path(__file__).parent.absolute()
+Vars = namedtuple(
+    "Vars",
+    [
+        "OS",
+        "TAG",
+        "VERSION",
+        "IMAGE_NAME",
+        "SHORT_VERSION",
+        "TEST_DIR",
+    ],
+)
+OS = os.getenv("TARGET").lower()
+VERSION = os.getenv("VERSION")
+
+VARS = Vars(
+    OS=OS,
+    TAG=TAGS.get(OS),
+    VERSION=VERSION,
+    IMAGE_NAME=os.getenv("IMAGE_NAME"),
+    SHORT_VERSION=VERSION.replace(".", ""),
+    TEST_DIR=TEST_DIR,
+)

--- a/test/constants.py
+++ b/test/constants.py
@@ -1,5 +1,0 @@
-TAGS = {
-    "rhel8": "-ubi8",
-    "rhel9": "-ubi9",
-    "rhel10": "-ubi10",
-}

--- a/test/test_ocp_ex_template.py
+++ b/test/test_ocp_ex_template.py
@@ -8,7 +8,9 @@ class TestHTTPDExExampleRepo:
     def setup_method(self):
         self.template_name = get_service_image(VARS.IMAGE_NAME)
         self.oc_api = OpenShiftAPI(
-            pod_name_prefix=self.template_name, version=VARS.VERSION, shared_cluster=True
+            pod_name_prefix=self.template_name,
+            version=VARS.VERSION,
+            shared_cluster=True,
         )
 
     def teardown_method(self):

--- a/test/test_ocp_ex_template.py
+++ b/test/test_ocp_ex_template.py
@@ -19,7 +19,9 @@ IMAGE_NAME = os.getenv("IMAGE_NAME")
 class TestHTTPDExExampleRepo:
     def setup_method(self):
         self.template_name = get_service_image(IMAGE_NAME)
-        self.oc_api = OpenShiftAPI(pod_name_prefix=self.template_name, version=VERSION)
+        self.oc_api = OpenShiftAPI(
+            pod_name_prefix=self.template_name, version=VERSION, shared_cluster=True
+        )
 
     def teardown_method(self):
         self.oc_api.delete_project()

--- a/test/test_ocp_ex_template.py
+++ b/test/test_ocp_ex_template.py
@@ -1,26 +1,14 @@
-import os
-import sys
-
-from pathlib import Path
-
 from container_ci_suite.openshift import OpenShiftAPI
-from container_ci_suite.utils import get_service_image, check_variables
+from container_ci_suite.utils import get_service_image
 
-if not check_variables():
-    print("At least one variable from IMAGE_NAME, OS, VERSION is missing.")
-    sys.exit(1)
-
-
-TEST_DIR = Path(os.path.abspath(os.path.dirname(__file__)))
-VERSION = os.getenv("VERSION")
-IMAGE_NAME = os.getenv("IMAGE_NAME")
+from conftest import VARS
 
 
 class TestHTTPDExExampleRepo:
     def setup_method(self):
-        self.template_name = get_service_image(IMAGE_NAME)
+        self.template_name = get_service_image(VARS.IMAGE_NAME)
         self.oc_api = OpenShiftAPI(
-            pod_name_prefix=self.template_name, version=VERSION, shared_cluster=True
+            pod_name_prefix=self.template_name, version=VARS.VERSION, shared_cluster=True
         )
 
     def teardown_method(self):
@@ -28,7 +16,7 @@ class TestHTTPDExExampleRepo:
 
     def test_httpd_ex_template_inside_cluster(self):
         assert self.oc_api.deploy_s2i_app(
-            image_name=IMAGE_NAME,
+            image_name=VARS.IMAGE_NAME,
             app="https://github.com/sclorg/httpd-ex#master",
             context=".",
         )

--- a/test/test_ocp_imagestream_s2i.py
+++ b/test/test_ocp_imagestream_s2i.py
@@ -1,34 +1,26 @@
-import os
-import sys
-
 from container_ci_suite.openshift import OpenShiftAPI
-from container_ci_suite.utils import get_service_image, check_variables
+from container_ci_suite.utils import get_service_image
 
-
-if not check_variables():
-    print("At least one variable from IMAGE_NAME, OS, SINGLE_VERSION is missing.")
-    sys.exit(1)
-
-IMAGE_NAME = os.getenv("IMAGE_NAME")
-OS = os.getenv("OS")
-VERSION = os.getenv("VERSION")
+from conftest import VARS
 
 
 class TestHTTPDImagestreamS2I:
     def setup_method(self):
-        self.template_name = get_service_image(IMAGE_NAME)
+        self.template_name = get_service_image(VARS.IMAGE_NAME)
         self.oc_api = OpenShiftAPI(
-            pod_name_prefix=self.template_name, version=VERSION, shared_cluster=True
+            pod_name_prefix=self.template_name,
+            version=VARS.VERSION,
+            shared_cluster=True
         )
 
     def teardown_method(self):
         self.oc_api.delete_project()
 
     def test_inside_cluster(self):
-        os_name = "".join(i for i in OS if not i.isdigit())
+        os_name = "".join(i for i in VARS.OS if not i.isdigit())
         assert self.oc_api.deploy_imagestream_s2i(
             imagestream_file=f"imagestreams/httpd-{os_name}.json",
-            image_name=IMAGE_NAME,
+            image_name=VARS.IMAGE_NAME,
             app="https://github.com/sclorg/httpd-container.git",
             context="examples/sample-test-app",
             service_name=self.template_name,

--- a/test/test_ocp_imagestream_s2i.py
+++ b/test/test_ocp_imagestream_s2i.py
@@ -17,7 +17,9 @@ VERSION = os.getenv("VERSION")
 class TestHTTPDImagestreamS2I:
     def setup_method(self):
         self.template_name = get_service_image(IMAGE_NAME)
-        self.oc_api = OpenShiftAPI(pod_name_prefix=self.template_name, version=VERSION)
+        self.oc_api = OpenShiftAPI(
+            pod_name_prefix=self.template_name, version=VERSION, shared_cluster=True
+        )
 
     def teardown_method(self):
         self.oc_api.delete_project()

--- a/test/test_ocp_imagestreams.py
+++ b/test/test_ocp_imagestreams.py
@@ -1,24 +1,14 @@
-import os
-import sys
-
-from pathlib import Path
-
 from container_ci_suite.imagestreams import ImageStreamChecker
-from container_ci_suite.utils import check_variables
 
-TEST_DIR = Path(os.path.abspath(os.path.dirname(__file__)))
-
-if not check_variables():
-    print("At least one variable from IMAGE_NAME, OS, SINGLE_VERSION is missing.")
-    sys.exit(1)
+from conftest import VARS
 
 
 class TestLatestImagestreams:
 
     def setup_method(self):
-        self.isc = ImageStreamChecker(working_dir=TEST_DIR.parent.parent)
+        self.isc = ImageStreamChecker(working_dir=VARS.TEST_DIR.parent.parent)
 
     def test_latest_imagestream(self):
         self.latest_version = self.isc.get_latest_version()
-        assert self.latest_version != ""
+        assert self.latest_version
         self.isc.check_imagestreams(self.latest_version)

--- a/test/test_ocp_integration.py
+++ b/test/test_ocp_integration.py
@@ -1,24 +1,14 @@
-import os
-import sys
-
 from container_ci_suite.openshift import OpenShiftAPI
-from container_ci_suite.utils import get_service_image, check_variables
+from container_ci_suite.utils import get_service_image
 
-
-if not check_variables():
-    print("At least one variable from IMAGE_NAME, OS, VERSION is missing.")
-    sys.exit(1)
-
-
-VERSION = os.getenv("VERSION")
-IMAGE_NAME = os.getenv("IMAGE_NAME")
+from conftest import VARS
 
 
 class TestHTTPDIntegrationTemplate:
     def setup_method(self):
-        self.template_name = get_service_image(IMAGE_NAME)
+        self.template_name = get_service_image(VARS.IMAGE_NAME)
         self.oc_api = OpenShiftAPI(
-            pod_name_prefix=self.template_name, version=VERSION, shared_cluster=True
+            pod_name_prefix=self.template_name, version=VARS.VERSION, shared_cluster=True
         )
 
     def teardown_method(self):
@@ -26,7 +16,7 @@ class TestHTTPDIntegrationTemplate:
 
     def test_httpd_ex_template_inside_cluster(self):
         assert self.oc_api.deploy_s2i_app(
-            image_name=IMAGE_NAME,
+            image_name=VARS.IMAGE_NAME,
             app="https://github.com/sclorg/httpd-container.git",
             context="examples/sample-test-app",
         )

--- a/test/test_ocp_integration.py
+++ b/test/test_ocp_integration.py
@@ -17,7 +17,9 @@ IMAGE_NAME = os.getenv("IMAGE_NAME")
 class TestHTTPDIntegrationTemplate:
     def setup_method(self):
         self.template_name = get_service_image(IMAGE_NAME)
-        self.oc_api = OpenShiftAPI(pod_name_prefix=self.template_name, version=VERSION)
+        self.oc_api = OpenShiftAPI(
+            pod_name_prefix=self.template_name, version=VERSION, shared_cluster=True
+        )
 
     def teardown_method(self):
         self.oc_api.delete_project()

--- a/test/test_ocp_shared_helm_imagestreams.py
+++ b/test/test_ocp_shared_helm_imagestreams.py
@@ -1,21 +1,23 @@
-import os
-
 import pytest
-from pathlib import Path
 
 from container_ci_suite.helm import HelmChartsAPI
 
-test_dir = Path(os.path.abspath(os.path.dirname(__file__)))
+from conftest import VARS
 
 
 class TestHelmRHELHttpdImageStreams:
 
     def setup_method(self):
         package_name = "redhat-httpd-imagestreams"
-        path = test_dir
-        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir, shared_cluster=True)
+        self.hc_api = HelmChartsAPI(
+            path=VARS.TEST_DIR,
+            package_name=package_name,
+            tarball_dir=VARS.TEST_DIR,
+            shared_cluster=True
+        )
         self.hc_api.clone_helm_chart_repo(
-            repo_url="https://github.com/sclorg/helm-charts", repo_name="helm-charts",
+            repo_url="https://github.com/sclorg/helm-charts",
+            repo_name="helm-charts",
             subdir="charts/redhat"
         )
 

--- a/test/test_ocp_shared_helm_template.py
+++ b/test/test_ocp_shared_helm_template.py
@@ -1,35 +1,20 @@
-import os
-import sys
-
-from pathlib import Path
-
 from container_ci_suite.helm import HelmChartsAPI
-from container_ci_suite.utils import check_variables
 
-from constants import TAGS
-
-
-if not check_variables():
-    print("At least one variable from OS, VERSION is missing.")
-    sys.exit(1)
-
-test_dir = Path(os.path.abspath(os.path.dirname(__file__)))
-
-VERSION = os.getenv("VERSION")
-IMAGE_NAME = os.getenv("IMAGE_NAME")
-OS = os.getenv("OS")
-
-TAG = TAGS.get(OS)
+from conftest import VARS
 
 
 class TestHelmHTTPDTemplate:
 
     def setup_method(self):
         package_name = "redhat-httpd-template"
-        path = test_dir
-        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir, shared_cluster=True)
+        self.hc_api = HelmChartsAPI(
+            path=VARS.TEST_DIR, package_name=package_name,
+            tarball_dir=VARS.TEST_DIR,
+            shared_cluster=True
+        )
         self.hc_api.clone_helm_chart_repo(
-            repo_url="https://github.com/sclorg/helm-charts", repo_name="helm-charts",
+            repo_url="https://github.com/sclorg/helm-charts",
+            repo_name="helm-charts",
             subdir="charts/redhat"
         )
 
@@ -37,9 +22,9 @@ class TestHelmHTTPDTemplate:
         self.hc_api.delete_project()
 
     def test_package_persistent_by_helm_chart_test(self):
-        new_version = VERSION
-        if "micro" in VERSION:
-            new_version = VERSION.replace("-micro", "")
+        new_version = VARS.VERSION
+        if "micro" in VARS.VERSION:
+            new_version = VARS.VERSION.replace("-micro", "")
         self.hc_api.package_name = "redhat-httpd-imagestreams"
         self.hc_api.helm_package()
         assert self.hc_api.helm_installation()
@@ -47,9 +32,11 @@ class TestHelmHTTPDTemplate:
         self.hc_api.helm_package()
         assert self.hc_api.helm_installation(
             values={
-                "httpd_version": f"{new_version}{TAG}",
+                "httpd_version": f"{new_version}{VARS.TAG}",
                 "namespace": self.hc_api.namespace
             }
         )
         assert self.hc_api.is_s2i_pod_running(pod_name_prefix="httpd-example")
-        assert self.hc_api.test_helm_chart(expected_str=["Welcome to your static httpd application on OpenShift"])
+        assert self.hc_api.test_helm_chart(
+            expected_str=["Welcome to your static httpd application on OpenShift"]
+        )


### PR DESCRIPTION
Let's decide is shared_cluster is used by variable in file `/root/shared_cluster.json`
delivered during the instance preparation.

Update also PyTest suite like we do in mariadb-container or mysql-container or the rest.
<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->

<!-- issue-commentator = {"comment-id":"4439931089"} -->

<!-- testing-farm = {"lock":"false","comment-id":"4440017517","data":[{"id":"86036a43-5cff-4e11-921b-8bbf04c0cccb","name":"RHEL10 - PyTest - OpenShift 4 - 2.4","runTime":3587.608123,"created":"2026-05-15T08:42:03.559176","updated":"2026-05-15T08:42:03.559184","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/86036a43-5cff-4e11-921b-8bbf04c0cccb\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/86036a43-5cff-4e11-921b-8bbf04c0cccb/pipeline.log\">pipeline</a>"]},{"id":"02fbc578-c452-49ef-b8a8-d6227048da68","name":"RHEL8 - PyTest - OpenShift 4 - 2.4","status":"complete","outcome":"passed","runTime":1342.088221,"created":"2026-05-15T07:40:48.014826","updated":"2026-05-15T07:40:48.014833","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/02fbc578-c452-49ef-b8a8-d6227048da68\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/02fbc578-c452-49ef-b8a8-d6227048da68/pipeline.log\">pipeline</a>"]},{"id":"a079e4b8-123a-43da-94ff-deec4fdd5873","name":"RHEL9 - PyTest - OpenShift 4 - 2.4","status":"complete","outcome":"passed","runTime":1738.681255,"created":"2026-05-15T07:40:51.871521","updated":"2026-05-15T07:40:51.871530","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a079e4b8-123a-43da-94ff-deec4fdd5873\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a079e4b8-123a-43da-94ff-deec4fdd5873/pipeline.log\">pipeline</a>"]}]} -->